### PR TITLE
Support enumerable extra data

### DIFF
--- a/src/Pidget.Client/Pidget.Client.csproj
+++ b/src/Pidget.Client/Pidget.Client.csproj
@@ -19,6 +19,11 @@
 
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/mausworks/pidget.git</RepositoryUrl>
+
+    <!--
+      Not all public members have to be documented.
+    -->
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Pidget.Client/SentryEventBuilder.cs
+++ b/src/Pidget.Client/SentryEventBuilder.cs
@@ -114,6 +114,21 @@ namespace Pidget.Client
             return this;
         }
 
+         /// <summary>
+        /// Adds a collection of extra data to the event.
+        /// </summary>
+        /// <param name="data">A collection of named data.</param>
+        public SentryEventBuilder AddExtraData(
+            IEnumerable<KeyValuePair<string, object>> data)
+        {
+            foreach (var kvp in data)
+            {
+                _extraData.Add(kvp.Key, kvp.Value);
+            }
+
+            return this;
+        }
+
         /// <summary>
         /// Adds the provided data to the fingerprint.
         /// </summary>

--- a/test/Pidget.Client.Test/SentryEventBuilderTests.cs
+++ b/test/Pidget.Client.Test/SentryEventBuilderTests.cs
@@ -97,6 +97,45 @@ namespace Pidget.Client.Test
             Assert.Equal(value, extraData.First().Value);
         }
 
+        [Theory, InlineData("extra_data", "foo", "bar", "baz")]
+        public void AddEnumerableExtraData(params object[] data)
+        {
+            var builder = new SentryEventBuilder()
+                .SetException(new Exception())
+                .AddExtraData(ToNamedPairs<object>(data));
+
+            var extraData = builder.Build().Extra;
+
+            var idx = 0;
+
+            for (var c = 1; idx < extraData.Count; c += 2)
+            {
+                var pair = extraData.ElementAt(idx);
+
+                Assert.Equal(data[c - 1], pair.Key);
+                Assert.Equal(data[c], pair.Value);
+
+                idx++;
+            }
+        }
+
+        private IEnumerable<KeyValuePair<string, TValue>> ToNamedPairs<TValue>(params object[] extraData)
+        {
+            if (extraData.Length % 2 != 0)
+            {
+                throw new NotSupportedException(
+                    "Cannot created named pairs.");
+            }
+
+            for (var i = 0; i < extraData.Length; i += 2)
+            {
+                var name = extraData[i].ToString();
+                var value = (TValue)extraData[i + 1];
+
+                yield return new KeyValuePair<string, TValue>(name, value);
+            }
+        }
+
         [Theory, InlineData("foo", "bar")]
         public void AddFingerprintData(params string[] data)
         {


### PR DESCRIPTION
This PR adds a method to the `SentryEventBuilder` which allows for adding enumerable extra data.

Usage:

```csharp
builder.AddExtraData(new Dictionary<string, object> { { "foo", "bar" } };
```