### PR TITLE
Hotfixes

### DIFF
--- a/src/Pidget.AspNet/Pidget.AspNet.csproj
+++ b/src/Pidget.AspNet/Pidget.AspNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DebugType>Full</DebugType>

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -46,7 +46,7 @@ namespace Pidget.Client.Http
             using (var stream = _serializer.Serialize(eventData))
             {
                 var response = await _httpClient.SendAsync(
-                    GetRequest(IssueAuth(), stream));
+                    GetRequest(IssueAuth(), stream)).ConfigureAwait(false);
 
                 using (var body = await response.Content.ReadAsStreamAsync())
                 {

--- a/src/Pidget.Client/Pidget.Client.csproj
+++ b/src/Pidget.Client/Pidget.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DebugType>Full</DebugType>
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Pidget.Client/Pidget.Client.csproj
+++ b/src/Pidget.Client/Pidget.Client.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Some things which were overlooked in 2.0.0.

- Added `.ConfigureAwait(false)` when awaiting response. If not se, `CaptureAsync(...).Result` is likely to cause a dead lock.
- Upgraded to latest version of Json.Net. The 9.x.x versions all targeted old framework assemblies and caused downgrade problems.
- Version bump to 2.0.1