### PR TITLE
User feature

### DIFF
--- a/src/Pidget.AspNet/ExceptionReportingMiddleware.cs
+++ b/src/Pidget.AspNet/ExceptionReportingMiddleware.cs
@@ -46,14 +46,25 @@ namespace Pidget.AspNet
 
         private async Task<string> CaptureAsync(Exception ex, HttpContext context)
             => await _sentryClient.CaptureAsync(e
-                => BuildEvent(ex, context.Request, e));
+                => BuildEvent(ex, context, e));
 
-        private void BuildEvent(Exception ex, HttpRequest request,
+        private void BuildEvent(Exception ex, HttpContext context,
             SentryEventBuilder sentryEvent)
         {
             sentryEvent.SetException(ex);
 
-            AddRequestData(sentryEvent, request);
+            AddUserData(sentryEvent, context);
+            AddRequestData(sentryEvent, context.Request);
+        }
+
+        private void AddUserData(SentryEventBuilder sentryEvent, HttpContext context)
+        {
+            var user = UserDataProvider.Default.GetUserData(context);
+
+            if (user != null)
+            {
+                sentryEvent.SetUserData(user);
+            }
         }
 
         private void AddRequestData(SentryEventBuilder sentryEvent, HttpRequest request)

--- a/src/Pidget.AspNet/UserDataProvider.cs
+++ b/src/Pidget.AspNet/UserDataProvider.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Pidget.Client.DataModels;
+
+namespace Pidget.AspNet
+{
+    public class UserDataProvider
+    {
+        public static UserDataProvider Default { get; }
+             = new UserDataProvider();
+
+        public UserData GetUserData(HttpContext context)
+        {
+            AssertContextNotNull(context);
+
+            var user = context.User == null
+                ? new UserData()
+                : new UserData
+                {
+                    Id = GetId(context.User),
+                    UserName = GetUserName(context.User),
+                    Email = GetEmail(context.User),
+                };
+
+            if (context.Connection != null)
+            {
+                user.IpAddress = GetIpAddress(context.Connection);
+            }
+
+            return user;
+        }
+
+        private void AssertContextNotNull(HttpContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+        }
+
+        public string GetUserName(ClaimsPrincipal user)
+            => user.Identity?.Name
+            ?? user.FindFirst(ClaimTypes.Name)?.Value;
+
+        public string GetEmail(ClaimsPrincipal user)
+            => user.FindFirst(ClaimTypes.Email)?.Value;
+
+        public string GetId(ClaimsPrincipal user)
+            => user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        public string GetIpAddress(ConnectionInfo connection)
+            => connection.RemoteIpAddress?.ToString();
+    }
+}

--- a/src/Pidget.Client/DataModels/SentryEventData.cs
+++ b/src/Pidget.Client/DataModels/SentryEventData.cs
@@ -41,5 +41,8 @@ namespace Pidget.Client.DataModels
 
         [JsonProperty("request")]
         public RequestData Request { get; set; }
+
+        [JsonProperty("user")]
+        public UserData User { get; set; }
     }
 }

--- a/src/Pidget.Client/DataModels/UserData.cs
+++ b/src/Pidget.Client/DataModels/UserData.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Pidget.Client.DataModels
+{
+    public class UserData
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("username")]
+        public string UserName { get; set; }
+
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        [JsonProperty("ip_address")]
+        public string IpAddress { get; set; }
+    }
+}

--- a/src/Pidget.Client/SentryEventBuilder.cs
+++ b/src/Pidget.Client/SentryEventBuilder.cs
@@ -20,6 +20,8 @@ namespace Pidget.Client
 
         private RequestData _requestData;
 
+        private UserData _userData;
+
         private readonly Dictionary<string, string> _tags
             = new Dictionary<string, string>(4);
 
@@ -143,6 +145,13 @@ namespace Pidget.Client
             return this;
         }
 
+        public SentryEventBuilder SetUserData(UserData user)
+        {
+            _userData = user;
+
+            return this;
+        }
+
         public SentryEventBuilder SetRequestData(RequestData request)
         {
             _requestData = request;
@@ -167,7 +176,8 @@ namespace Pidget.Client
                 Tags = _tags,
                 Extra = _extraData,
                 Fingerprint = _fingerprint,
-                Request = _requestData
+                Request = _requestData,
+                User = _userData
             };
         }
 

--- a/test/Pidget.AspNet.Test/ExceptionReportingMiddlewareTests.cs
+++ b/test/Pidget.AspNet.Test/ExceptionReportingMiddlewareTests.cs
@@ -46,8 +46,6 @@ namespace Pidget.AspNet.Test
         {
             var requestMock = new Mock<HttpRequest>();
 
-            requestMock.SetupAllProperties();
-
             var contextMock = new Mock<HttpContext>();
 
             contextMock.Setup(m => m.Items)

--- a/test/Pidget.AspNet.Test/ExceptionReportingMiddlewareTests.cs
+++ b/test/Pidget.AspNet.Test/ExceptionReportingMiddlewareTests.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -58,6 +60,104 @@ namespace Pidget.AspNet.Test
                 Dsn.Create(ExceptionReportingOptions.Dsn));
 
             clientMock.Setup(c => c.SendEventAsync(It.IsAny<SentryEventData>()))
+                .ReturnsAsync(eventId)
+                .Verifiable();
+
+            var middleware = CreateMiddleware(Next_Throw, clientMock.Object);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => middleware.Invoke(contextMock.Object));
+
+            clientMock.Verify();
+        }
+
+        [Theory, InlineData("1", "POST", "https://foo.bar/baz?foo=bar")]
+        public async Task CapturesRequestData(string eventId,
+            string method,
+            string url)
+        {
+            var uri = new Uri(url, UriKind.Absolute);
+            var requestMock = new Mock<HttpRequest>();
+
+            requestMock.SetupGet(r => r.Method).Returns(method);
+
+            requestMock.SetupGet(r => r.Scheme).Returns(uri.Scheme);
+            requestMock.SetupGet(r => r.Host).Returns(new HostString(uri.Host));
+            requestMock.SetupGet(r => r.Path).Returns(uri.AbsolutePath);
+
+            requestMock.SetupGet(r => r.QueryString)
+                .Returns(QueryString.FromUriComponent(uri.Query));
+            requestMock.SetupGet(r => r.Query)
+                .Returns(new QueryCollection(QueryHelpers.ParseQuery(uri.Query)));
+
+            var contextMock = new Mock<HttpContext>();
+
+            contextMock.Setup(m => m.Items)
+                .Returns(new Dictionary<object, object>());
+
+            contextMock.SetupGet(c => c.Request)
+                .Returns(requestMock.Object);
+
+            var clientMock = new Mock<SentryClient>(
+                Dsn.Create(ExceptionReportingOptions.Dsn));
+
+            clientMock.Setup(c => c.SendEventAsync(It.Is<SentryEventData>(r
+                => r.Request.Url == url.Split('?', StringSplitOptions.None)[0]
+                && r.Request.Method == method
+                && r.Request.QueryString == uri.Query)))
+                .ReturnsAsync(eventId)
+                .Verifiable();
+
+            var middleware = CreateMiddleware(Next_Throw, clientMock.Object);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => middleware.Invoke(contextMock.Object));
+
+            clientMock.Verify();
+        }
+
+        [Theory, InlineData("1", "1", "user", "foo@bar", "0.0.0.0")]
+        public async Task CapturesUserData(string eventId,
+            string userId,
+            string userName,
+            string email,
+            string ipAddress)
+        {
+            var connectionMock = new Mock<ConnectionInfo>();
+
+            connectionMock.SetupGet(c => c.RemoteIpAddress)
+                .Returns(IPAddress.Parse(ipAddress))
+                .Verifiable();
+
+            var user = UserDataProviderTests.MockUser(
+                Tuple.Create(ClaimTypes.NameIdentifier, userId),
+                Tuple.Create(ClaimTypes.Name, userName),
+                Tuple.Create(ClaimTypes.Email, email));
+
+            var contextMock = new Mock<HttpContext>();
+
+            contextMock.SetupGet(c => c.Connection)
+                .Returns(connectionMock.Object)
+                .Verifiable();
+
+            contextMock.SetupGet(c => c.User)
+                .Returns(user)
+                .Verifiable();
+
+            contextMock.Setup(m => m.Items)
+                .Returns(new Dictionary<object, object>());
+
+            contextMock.SetupGet(c => c.Request)
+                .Returns(Mock.Of<HttpRequest>());
+
+            var clientMock = new Mock<SentryClient>(
+                Dsn.Create(ExceptionReportingOptions.Dsn));
+
+            clientMock.Setup(c => c.SendEventAsync(It.Is<SentryEventData>(r
+                 => r.User.Id == userId
+                 && r.User.UserName == userName
+                 && r.User.Email == email
+                 && r.User.IpAddress == ipAddress)))
                 .ReturnsAsync(eventId)
                 .Verifiable();
 

--- a/test/Pidget.AspNet.Test/UserDataProviderTests.cs
+++ b/test/Pidget.AspNet.Test/UserDataProviderTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Security.Claims;
+using System.Security.Principal;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Pidget.Client.DataModels;
+using Xunit;
+
+namespace Pidget.AspNet
+{
+    public class UserDataProviderTests
+    {
+        [Fact]
+        public void GetUserData_ThrowsArgumentNull_ForNullContext()
+            => Assert.Throws<ArgumentNullException>(()
+                => UserDataProvider.Default.GetUserData(null));
+
+        [Theory, InlineData("1")]
+        public void GetId_UsesNameIdentifierClaim(string id)
+        {
+            var user = MockUser(Tuple.Create(ClaimTypes.NameIdentifier, id));
+
+            Assert.Equal(id, UserDataProvider.Default.GetId(user));
+        }
+
+        [Theory, InlineData("foo@bar")]
+        public void GetEmail_ReturnsEmailClaim(string email)
+        {
+            var user = MockUser(Tuple.Create(ClaimTypes.Email, email));
+
+            Assert.Equal(email, UserDataProvider.Default.GetEmail(user));
+        }
+
+        [Theory]
+        [InlineData("user")]
+        public void GetUserName_ReturnsIdentityName(string userName)
+        {
+            var identityMock = new Mock<IIdentity>();
+
+            identityMock.SetupGet(i => i.Name)
+                .Returns(userName)
+                .Verifiable();
+
+            var user = new ClaimsPrincipal(identityMock.Object);
+
+            Assert.Equal(userName, UserDataProvider.Default.GetUserName(user));
+
+            identityMock.Verify();
+        }
+
+        [Theory]
+        [InlineData("user")]
+        public void GetUserName_NoIdentityFallbacksToNameClaim(string userName)
+        {
+            var user = MockUser(Tuple.Create(ClaimTypes.Name, userName));
+
+            Assert.Equal(userName, UserDataProvider.Default.GetUserName(user));
+        }
+
+        [Theory]
+        [InlineData("user")]
+        public void GetUserName_NoIdentityNameFallbacksToNameClaim(
+            string userName)
+        {
+            var identityMock = new Mock<ClaimsIdentity>();
+
+            identityMock.SetupGet(i => i.Name)
+                .Returns(null as string)
+                .Verifiable();
+
+            identityMock.Setup(i => i.FindFirst(ClaimTypes.Name))
+                .Returns(new Claim(ClaimTypes.Name, userName))
+                .Verifiable();
+
+            var user = new ClaimsPrincipal(identityMock.Object);
+
+            Assert.Equal(userName, UserDataProvider.Default.GetUserName(user));
+
+            identityMock.Verify();
+        }
+
+        [Theory, InlineData("0.0.0.0")]
+        public void GetIpAddress(string ipAddress)
+        {
+            var connectionMock = new Mock<ConnectionInfo>();
+
+            connectionMock.SetupGet(c => c.RemoteIpAddress)
+                .Returns(IPAddress.Parse(ipAddress))
+                .Verifiable();
+
+            Assert.Equal(ipAddress,
+                UserDataProvider.Default.GetIpAddress(connectionMock.Object));
+
+            connectionMock.Verify();
+        }
+
+        [Theory]
+        [InlineData("1", "foo", "foo@bar", null)]
+        [InlineData("1", "foo", "foo@bar", "0.0.0.0")]
+        public void GetUserData(string id,
+            string userName,
+            string email,
+            string ipAddress)
+        {
+            var user = MockUser(Tuple.Create(ClaimTypes.NameIdentifier, id),
+                Tuple.Create(ClaimTypes.Name, userName),
+                Tuple.Create(ClaimTypes.Email, email));
+
+            var connectionMock = new Mock<ConnectionInfo>();
+
+            connectionMock.SetupGet(c => c.RemoteIpAddress)
+                .Returns(ipAddress != null
+                    ? IPAddress.Parse(ipAddress)
+                    : null)
+                .Verifiable();
+
+            var contextMock = new Mock<HttpContext>();
+
+            contextMock.SetupGet(c => c.User)
+                .Returns(user)
+                .Verifiable();
+
+            contextMock.SetupGet(c => c.Connection)
+                .Returns(connectionMock.Object)
+                .Verifiable();
+
+            var data = UserDataProvider.Default.GetUserData(contextMock.Object);
+
+            Assert.Equal(id, data.Id);
+            Assert.Equal(userName, data.UserName);
+            Assert.Equal(email, data.Email);
+            Assert.Equal(ipAddress, data.IpAddress);
+
+            connectionMock.Verify();
+            contextMock.Verify();
+        }
+
+        [Fact]
+        public void GetUserData_NoClaims_NoConnection()
+        {
+            var user = MockUser();
+            var contextMock = new Mock<HttpContext>();
+
+            contextMock.SetupGet(c => c.User)
+                .Returns(user)
+                .Verifiable();
+
+            var data = UserDataProvider.Default.GetUserData(contextMock.Object);
+
+            Assert.Null(data.Id);
+            Assert.Null(data.UserName);
+            Assert.Null(data.Email);
+            Assert.Null(data.IpAddress);
+
+            contextMock.Verify();
+        }
+
+        public static ClaimsPrincipal MockUser(params Tuple<string, string>[] claims)
+        {
+            var identity = new ClaimsIdentity(claims
+                .Select(c => new Claim(c.Item1, c.Item2)));
+
+            return new ClaimsPrincipal(identity);
+        }
+    }
+}

--- a/test/Pidget.Client.Test/SentryEventBuilderTests.cs
+++ b/test/Pidget.Client.Test/SentryEventBuilderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Pidget.Client.DataModels;
 using Xunit;
 
 namespace Pidget.Client.Test
@@ -119,6 +120,44 @@ namespace Pidget.Client.Test
             }
         }
 
+        [Fact]
+        public void SetRequestData()
+        {
+            var expectedData = new RequestData();
+
+            var builder = new SentryEventBuilder()
+                .SetException(new Exception())
+                .SetRequestData(expectedData);
+
+            var requestData = builder.Build().Request;
+
+            Assert.Same(expectedData, requestData);
+        }
+
+        [Fact]
+        public void SetUserData()
+        {
+            var expectedData = new UserData();
+
+            var builder = new SentryEventBuilder()
+                .SetException(new Exception())
+                .SetUserData(expectedData);
+
+            var userData = builder.Build().User;
+
+            Assert.Same(expectedData, userData);
+        }
+
+        [Theory, InlineData("foo", "bar")]
+        public void AddFingerprintData(params string[] data)
+        {
+            var builder = new SentryEventBuilder()
+                .SetException(new Exception())
+                .AddFingerprintData(data);
+
+            Assert.Equal(data, builder.Build().Fingerprint);
+        }
+
         private IEnumerable<KeyValuePair<string, TValue>> ToNamedPairs<TValue>(params object[] extraData)
         {
             if (extraData.Length % 2 != 0)
@@ -134,16 +173,6 @@ namespace Pidget.Client.Test
 
                 yield return new KeyValuePair<string, TValue>(name, value);
             }
-        }
-
-        [Theory, InlineData("foo", "bar")]
-        public void AddFingerprintData(params string[] data)
-        {
-            var builder = new SentryEventBuilder()
-                .SetException(new Exception())
-                .AddFingerprintData(data);
-
-            Assert.Equal(data, builder.Build().Fingerprint);
         }
     }
 }


### PR DESCRIPTION
This pull request solves #6.

Capturing user data manually:

```csharp
client.CaptureAsync(e => e
  .SetMessage("test")
  .SetUserData(new UserData
  {
      Id = "1",
      UserName = "mausworks",
      Email = "me@fixz.se",
      Ip = "0.0.0.0"
  });
```

User data is automatically fetched from the `User` property in the `HttpContext`, if provided.
If you wish to manually extract data from the `HttpContext` the `UserDataProvider` may be used.