### PR TITLE
Arbitrary data model

### DIFF
--- a/src/Pidget.Client/DataModels/ArbitraryData.cs
+++ b/src/Pidget.Client/DataModels/ArbitraryData.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Pidget.Client.DataModels
+{
+    [JsonDictionary]
+    public class ArbitraryData : IReadOnlyDictionary<string, object>
+    {
+        public IEnumerable<string> Keys => _data.Keys;
+
+        public IEnumerable<object> Values => _data.Values;
+
+        public int Count => _data.Count;
+
+        public object this[string key] => _data[key];
+
+        private readonly IDictionary<string, object> _data
+            = new Dictionary<string, object>();
+
+        public ArbitraryData Set(string name, object data)
+        {
+            _data[name] = data;
+
+            return this;
+        }
+
+        public object Get(string name)
+        {
+            _data.TryGetValue(name, out object value);
+
+            return value;
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+            => _data.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public bool ContainsKey(string key)
+            => _data.ContainsKey(key);
+
+        public bool TryGetValue(string key, out object value)
+            => _data.TryGetValue(key, out value);
+    }
+}

--- a/src/Pidget.Client/DataModels/UserData.cs
+++ b/src/Pidget.Client/DataModels/UserData.cs
@@ -3,18 +3,32 @@ using Newtonsoft.Json;
 
 namespace Pidget.Client.DataModels
 {
-    public class UserData
+    public class UserData : ArbitraryData
     {
-        [JsonProperty("id")]
-        public string Id { get; set; }
+        public string Id
+        {
+            get => (string)Get("id");
+            set => Set("id", value);
+        }
 
-        [JsonProperty("username")]
-        public string UserName { get; set; }
+        public string UserName
+        {
+            get => (string)Get("username");
+            set => Set("username", value);
+        }
 
         [JsonProperty("email")]
-        public string Email { get; set; }
+        public string Email
+        {
+            get => (string)Get("email");
+            set => Set("email", value);
+        }
 
         [JsonProperty("ip_address")]
-        public string IpAddress { get; set; }
+        public string IpAddress
+        {
+            get => (string)Get("ip_address");
+            set => Set("ip_address", value);
+        }
     }
 }

--- a/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
+++ b/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Pidget.Client.DataModels;
+using Xunit;
+
+namespace Pidget.Client.Test.DataModels
+{
+    public class ArbitraryDataTests
+    {
+        [Theory, InlineData("some_data", 1)]
+        public void SetValue_GetsEnumerated(string key, object value)
+        {
+            var data = new ArbitraryData();
+
+            data.Set(key, value);
+
+            Assert.Equal(key, data.First().Key);
+            Assert.Equal(value, data.First().Value);
+        }
+
+        [Theory, InlineData("some_data", 1)]
+        public void GetSetValue(string key, object value)
+        {
+            var data = new ArbitraryData();
+
+            data.Set(key, value);
+
+            Assert.Equal(1, data.Count);
+            Assert.Equal(key, data.Keys.First());
+            Assert.Equal(value, data.Values.First());
+            Assert.Equal(value, data.Get(key));
+            Assert.Equal(value, data[key]);
+            Assert.True(data.ContainsKey(key));
+            Assert.True(data.TryGetValue(key, out object outValue));
+            Assert.Equal(value, outValue);
+        }
+    }
+}


### PR DESCRIPTION
This PR solves #7 by adding a model for arbitrary data. 

It is intended to be used in models where all keys are not predefined, such as in the [user](https://docs.sentry.io/clientdev/interfaces/user/) or [contexts](https://docs.sentry.io/clientdev/interfaces/contexts/) interface.

From the documentation on the user interface page:
> All other keys are stored as extra information but not specifically processed by sentry.

This is how a key of "is_nice" is displayed in sentry:
![is_nice](https://screenshots.firefoxusercontent.com/images/d92591b1-aaa4-4a16-a4b1-4c6b9ce1e7d4.png)

Classes deriving from this class may not simply use auto-properties for serialization, but must instead call `Get(key)` and `Set(key, value)`. This however liberates your from `JsonPropertyAttribute`s.