### PR TITLE
Contexts support.

### DIFF
--- a/src/Pidget.AspNet/Pidget.AspNet.csproj
+++ b/src/Pidget.AspNet/Pidget.AspNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DebugType>Full</DebugType>

--- a/src/Pidget.Client/DataModels/ArbitraryData.cs
+++ b/src/Pidget.Client/DataModels/ArbitraryData.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
-using Newtonsoft.Json;
 
 namespace Pidget.Client.DataModels
 {

--- a/src/Pidget.Client/DataModels/ArbitraryData.cs
+++ b/src/Pidget.Client/DataModels/ArbitraryData.cs
@@ -18,7 +18,7 @@ namespace Pidget.Client.DataModels
         public object this[string key] => _data[key];
 
         private readonly IDictionary<string, object> _data
-            = new Dictionary<string, object>();
+            = new Dictionary<string, object>(StringComparer.Ordinal);
 
         public ArbitraryData Set(string name, object data)
         {

--- a/src/Pidget.Client/DataModels/ArbitraryData.cs
+++ b/src/Pidget.Client/DataModels/ArbitraryData.cs
@@ -6,6 +6,9 @@ using Newtonsoft.Json;
 
 namespace Pidget.Client.DataModels
 {
+    /// <summary>
+    /// A dictionary-like name/object data structure.
+    /// </summary>
     public class ArbitraryData : IDictionary<string, object>
     {
         public ICollection<string> Keys => _data.Keys;

--- a/src/Pidget.Client/DataModels/ArbitraryData.cs
+++ b/src/Pidget.Client/DataModels/ArbitraryData.cs
@@ -6,30 +6,29 @@ using Newtonsoft.Json;
 
 namespace Pidget.Client.DataModels
 {
-    [JsonDictionary]
-    public class ArbitraryData : IReadOnlyDictionary<string, object>
+    public class ArbitraryData : IDictionary<string, object>
     {
-        public IEnumerable<string> Keys => _data.Keys;
+        public ICollection<string> Keys => _data.Keys;
 
-        public IEnumerable<object> Values => _data.Values;
+        public ICollection<object> Values => _data.Values;
 
         public int Count => _data.Count;
 
-        public object this[string key] => _data[key];
+        public bool IsReadOnly => _data.IsReadOnly;
 
         private readonly IDictionary<string, object> _data
             = new Dictionary<string, object>(StringComparer.Ordinal);
 
-        public ArbitraryData Set(string name, object data)
-        {
-            _data[name] = data;
 
-            return this;
+        public object this[string key]
+        {
+            get => Get(key);
+            set => _data[key] = value;
         }
 
-        public object Get(string name)
+        private object Get(string key)
         {
-            _data.TryGetValue(name, out object value);
+            TryGetValue(key, out object value);
 
             return value;
         }
@@ -45,5 +44,26 @@ namespace Pidget.Client.DataModels
 
         public bool TryGetValue(string key, out object value)
             => _data.TryGetValue(key, out value);
+
+        public void Add(string key, object value)
+            => _data.Add(key, value);
+
+        public bool Remove(string key)
+            => _data.Remove(key);
+
+        public void Add(KeyValuePair<string, object> item)
+            => _data.Add(item);
+
+        public void Clear()
+            => _data.Clear();
+
+        public bool Contains(KeyValuePair<string, object> item)
+            => _data.Contains(item);
+
+        public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+            => _data.CopyTo(array, arrayIndex);
+
+        public bool Remove(KeyValuePair<string, object> item)
+            => _data.Remove(item);
     }
 }

--- a/src/Pidget.Client/DataModels/ContextsData.cs
+++ b/src/Pidget.Client/DataModels/ContextsData.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Pidget.Client.DataModels
+{
+    public class ContextsData : ArbitraryData
+    {
+        public OperatingSystemData OperatingSystem
+        {
+            get => Get("os") as OperatingSystemData;
+            set => Set("os", value);
+        }
+
+        public DeviceData Device
+        {
+            get => Get("device") as DeviceData;
+            set => Set("device", value);
+        }
+
+        public RuntimeData Runtime
+        {
+            get => Get("runtime") as RuntimeData;
+            set => Set("runtime", value);
+        }
+    }
+}

--- a/src/Pidget.Client/DataModels/ContextsData.cs
+++ b/src/Pidget.Client/DataModels/ContextsData.cs
@@ -1,11 +1,9 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Reflection;
-using Newtonsoft.Json;
-
 namespace Pidget.Client.DataModels
 {
+    /// <summary>
+    /// Provides additional contextual data, typically related to the current user.
+    /// See also: https://docs.sentry.io/clientdev/interfaces/contexts/
+    /// </summary>
     public class ContextsData : ArbitraryData
     {
         public OperatingSystemData OperatingSystem

--- a/src/Pidget.Client/DataModels/ContextsData.cs
+++ b/src/Pidget.Client/DataModels/ContextsData.cs
@@ -10,20 +10,20 @@ namespace Pidget.Client.DataModels
     {
         public OperatingSystemData OperatingSystem
         {
-            get => Get("os") as OperatingSystemData;
-            set => Set("os", value);
+            get => this["os"] as OperatingSystemData;
+            set => this["os"] = value;
         }
 
         public DeviceData Device
         {
-            get => Get("device") as DeviceData;
-            set => Set("device", value);
+            get => this["device"] as DeviceData;
+            set => this["device"] = value;
         }
 
         public RuntimeData Runtime
         {
-            get => Get("runtime") as RuntimeData;
-            set => Set("runtime", value);
+            get => this["runtime"] as RuntimeData;
+            set => this["runtime"] = value;
         }
     }
 }

--- a/src/Pidget.Client/DataModels/DeviceData.cs
+++ b/src/Pidget.Client/DataModels/DeviceData.cs
@@ -1,0 +1,47 @@
+namespace Pidget.Client.DataModels
+{
+    public class DeviceData : ArbitraryData
+    {
+        public string Name
+        {
+            get => Get("name") as string;
+            set => Set("name", value);
+        }
+
+        public string Family
+        {
+            get => Get("family") as string;
+            set => Set("family", value);
+        }
+
+        public string Model
+        {
+            get => Get("model") as string;
+            set => Set("model", value);
+        }
+
+        public string ModelId
+        {
+            get => Get("model_id") as string;
+            set => Set("model_id", value);
+        }
+
+        public string Architecture
+        {
+            get => Get("arch") as string;
+            set => Set("arch", value);
+        }
+
+        public double BatteryLevel
+        {
+            get => Get("battery_level") as string;
+            set => Set("battery_level", value);
+        }
+
+        public string Orientation
+        {
+            get => Get("orientation") as string;
+            set => Set("orientation", value);
+        }
+    }
+}

--- a/src/Pidget.Client/DataModels/DeviceData.cs
+++ b/src/Pidget.Client/DataModels/DeviceData.cs
@@ -1,5 +1,9 @@
 namespace Pidget.Client.DataModels
 {
+    /// <summary>
+    /// Describes the device that caused an event,
+    /// most appropriate for mobile applications.
+    /// </summary>
     public class DeviceData : ArbitraryData
     {
         public string Name

--- a/src/Pidget.Client/DataModels/DeviceData.cs
+++ b/src/Pidget.Client/DataModels/DeviceData.cs
@@ -4,44 +4,44 @@ namespace Pidget.Client.DataModels
     {
         public string Name
         {
-            get => Get("name") as string;
-            set => Set("name", value);
+            get => this["name"] as string;
+            set => this["name"] = value;
         }
 
         public string Family
         {
-            get => Get("family") as string;
-            set => Set("family", value);
+            get => this["family"] as string;
+            set => this["family"] = value;
         }
 
         public string Model
         {
-            get => Get("model") as string;
-            set => Set("model", value);
+            get => this["model"] as string;
+            set => this["model"] = value;
         }
 
         public string ModelId
         {
-            get => Get("model_id") as string;
-            set => Set("model_id", value);
+            get => this["model_id"] as string;
+            set => this["model_id"] = value;
         }
 
         public string Architecture
         {
-            get => Get("arch") as string;
-            set => Set("arch", value);
+            get => this["arch"] as string;
+            set => this["arch"] = value;
         }
 
-        public double BatteryLevel
+        public double? BatteryLevel
         {
-            get => Get("battery_level") as string;
-            set => Set("battery_level", value);
+            get => this["arch"] as double?;
+            set => this["battery_level"] = value;
         }
 
         public string Orientation
         {
-            get => Get("orientation") as string;
-            set => Set("orientation", value);
+            get => this["orientation"] as string;
+            set => this["orientation"] = value;
         }
     }
 }

--- a/src/Pidget.Client/DataModels/OperatingSystemData.cs
+++ b/src/Pidget.Client/DataModels/OperatingSystemData.cs
@@ -1,5 +1,8 @@
 namespace Pidget.Client.DataModels
 {
+    /// <summary>
+    /// Defines the operating system that caused an event.
+    /// </summary>
     public class OperatingSystemData : ArbitraryData
     {
         public string Name

--- a/src/Pidget.Client/DataModels/OperatingSystemData.cs
+++ b/src/Pidget.Client/DataModels/OperatingSystemData.cs
@@ -4,32 +4,32 @@ namespace Pidget.Client.DataModels
     {
         public string Name
         {
-            get => Get("name") as string;
-            set => Set("name", value);
+            get => this["name"] as string;
+            set => this["name"] = value;
         }
 
         public string Version
         {
-            get => Get("version") as string;
-            set => Set("version", value);
+            get => this["version"] as string;
+            set => this["version"] = value;
         }
 
         public string Build
         {
-            get => Get("build") as string;
-            set => Set("build", value);
+            get => this["build"] as string;
+            set => this["build"] = value;
         }
 
         public string KernelVersion
         {
-            get => Get("kernel_version") as string;
-            set => Set("kernel_version", value);
+            get => this["kernel_version"] as string;
+            set => this["kernel_version"] = value;
         }
 
         public bool? Rooted
         {
-            get => Get("rooted") as bool?;
-            set => Set("rooted", value);
+            get => this["rooted"] as bool?;
+            set => this["rooted"] = value;
         }
     }
 }

--- a/src/Pidget.Client/DataModels/OperatingSystemData.cs
+++ b/src/Pidget.Client/DataModels/OperatingSystemData.cs
@@ -1,0 +1,35 @@
+namespace Pidget.Client.DataModels
+{
+    public class OperatingSystemData : ArbitraryData
+    {
+        public string Name
+        {
+            get => Get("name") as string;
+            set => Set("name", value);
+        }
+
+        public string Version
+        {
+            get => Get("version") as string;
+            set => Set("version", value);
+        }
+
+        public string Build
+        {
+            get => Get("build") as string;
+            set => Set("build", value);
+        }
+
+        public string KernelVersion
+        {
+            get => Get("kernel_version") as string;
+            set => Set("kernel_version", value);
+        }
+
+        public bool? Rooted
+        {
+            get => Get("rooted") as bool?;
+            set => Set("rooted", value);
+        }
+    }
+}

--- a/src/Pidget.Client/DataModels/RuntimeData.cs
+++ b/src/Pidget.Client/DataModels/RuntimeData.cs
@@ -1,5 +1,8 @@
 namespace Pidget.Client.DataModels
 {
+    /// <summary>
+    /// Describes the runtime in more detail.
+    /// </summary>
     public class RuntimeData : ArbitraryData
     {
         public string Name

--- a/src/Pidget.Client/DataModels/RuntimeData.cs
+++ b/src/Pidget.Client/DataModels/RuntimeData.cs
@@ -4,14 +4,14 @@ namespace Pidget.Client.DataModels
     {
         public string Name
         {
-            get => Get("name") as string;
-            set => Set("name", value);
+            get => this["name"] as string;
+            set => this["name"] = value;
         }
 
         public string Version
         {
-            get => Get("version") as string;
-            set => Set("version", value);
+            get => this["version"] as string;
+            set => this["version"] = value;
         }
     }
 }

--- a/src/Pidget.Client/DataModels/RuntimeData.cs
+++ b/src/Pidget.Client/DataModels/RuntimeData.cs
@@ -1,0 +1,17 @@
+namespace Pidget.Client.DataModels
+{
+    public class RuntimeData : ArbitraryData
+    {
+        public string Name
+        {
+            get => Get("name") as string;
+            set => Set("name", value);
+        }
+
+        public string Version
+        {
+            get => Get("version") as string;
+            set => Set("version", value);
+        }
+    }
+}

--- a/src/Pidget.Client/DataModels/SentryEventData.cs
+++ b/src/Pidget.Client/DataModels/SentryEventData.cs
@@ -44,5 +44,8 @@ namespace Pidget.Client.DataModels
 
         [JsonProperty("user")]
         public UserData User { get; set; }
+
+        [JsonProperty("contexts")]
+        public ContextsData Contexts { get; set; }
     }
 }

--- a/src/Pidget.Client/DataModels/UserData.cs
+++ b/src/Pidget.Client/DataModels/UserData.cs
@@ -7,26 +7,26 @@ namespace Pidget.Client.DataModels
     {
         public string Id
         {
-            get => Get("id") as string;
-            set => Set("id", value);
+            get => this["id"] as string;
+            set => this["id"] = value;
         }
 
         public string UserName
         {
-            get => Get("username") as string;
-            set => Set("username", value);
+            get => this["username"] as string;
+            set => this["username"] = value;
         }
 
         public string Email
         {
-            get => Get("email") as string;
-            set => Set("email", value);
+            get => this["email"] as string;
+            set => this["email"] = value;
         }
 
         public string IpAddress
         {
-            get => Get("ip_address") as string;
-            set => Set("ip_address", value);
+            get => this["ip_address"] as string;
+            set => this["ip_address"] = value;
         }
     }
 }

--- a/src/Pidget.Client/DataModels/UserData.cs
+++ b/src/Pidget.Client/DataModels/UserData.cs
@@ -17,14 +17,12 @@ namespace Pidget.Client.DataModels
             set => Set("username", value);
         }
 
-        [JsonProperty("email")]
         public string Email
         {
             get => (string)Get("email");
             set => Set("email", value);
         }
 
-        [JsonProperty("ip_address")]
         public string IpAddress
         {
             get => (string)Get("ip_address");

--- a/src/Pidget.Client/DataModels/UserData.cs
+++ b/src/Pidget.Client/DataModels/UserData.cs
@@ -7,25 +7,25 @@ namespace Pidget.Client.DataModels
     {
         public string Id
         {
-            get => (string)Get("id");
+            get => Get("id") as string;
             set => Set("id", value);
         }
 
         public string UserName
         {
-            get => (string)Get("username");
+            get => Get("username") as string;
             set => Set("username", value);
         }
 
         public string Email
         {
-            get => (string)Get("email");
+            get => Get("email") as string;
             set => Set("email", value);
         }
 
         public string IpAddress
         {
-            get => (string)Get("ip_address");
+            get => Get("ip_address") as string;
             set => Set("ip_address", value);
         }
     }

--- a/src/Pidget.Client/Pidget.Client.csproj
+++ b/src/Pidget.Client/Pidget.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DebugType>Full</DebugType>

--- a/src/Pidget.Client/SentryEventBuilder.cs
+++ b/src/Pidget.Client/SentryEventBuilder.cs
@@ -30,6 +30,8 @@ namespace Pidget.Client
 
         private readonly List<string> _fingerprint = new List<string>(4);
 
+        private ContextsData _contextsData;
+
 
         /// <summary>
         /// Sets the captured exception.
@@ -159,6 +161,13 @@ namespace Pidget.Client
             return this;
         }
 
+        public SentryEventBuilder SetContexts(ContextsData contexts)
+        {
+            _contextsData = contexts;
+
+            return this;
+        }
+
         public SentryEventData Build()
         {
             AssertValidity();
@@ -177,7 +186,8 @@ namespace Pidget.Client
                 Extra = _extraData,
                 Fingerprint = _fingerprint,
                 Request = _requestData,
-                User = _userData
+                User = _userData,
+                Contexts = _contextsData
             };
         }
 

--- a/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
+++ b/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
@@ -15,7 +15,7 @@ namespace Pidget.Client.Test.DataModels
         {
             var data = new ArbitraryData();
 
-            data.Set(key, value);
+            data[key] = value;
 
             Assert.Equal(key, data.First().Key);
             Assert.Equal(value, data.First().Value);
@@ -26,12 +26,11 @@ namespace Pidget.Client.Test.DataModels
         {
             var data = new ArbitraryData();
 
-            data.Set(key, value);
+            data[key] = value;
 
             Assert.Equal(1, data.Count);
             Assert.Equal(key, data.Keys.First());
             Assert.Equal(value, data.Values.First());
-            Assert.Equal(value, data.Get(key));
             Assert.Equal(value, data[key]);
             Assert.True(data.ContainsKey(key));
             Assert.True(data.TryGetValue(key, out object outValue));

--- a/test/Pidget.Client.Test/DsnTests.cs
+++ b/test/Pidget.Client.Test/DsnTests.cs
@@ -6,15 +6,15 @@ namespace Pidget.Client.Test
 {
     public class DsnTests
     {
-        public const string PublicKey = "PUBLIC_KEY";
+        public const string PublicKey = "public_key";
 
-        public const string SecretKey = "SECRET_KEY";
+        public const string SecretKey = "secret_key";
 
-        public const string Host = "HOST";
+        public const string Host = "host";
 
-        public const string ProjectId = "PROJECT_ID";
+        public const string ProjectId = "project_id";
 
-        public const string Path = "/PATH/";
+        public const string Path = "/path/";
 
         public static readonly Dsn SentryDsn = Dsn.Create(
             $"https://{PublicKey}:{SecretKey}@{Host}{Path}{ProjectId}");
@@ -34,5 +34,16 @@ namespace Pidget.Client.Test
         [Fact]
         public void GetProjectId()
             => Assert.Equal(ProjectId, SentryDsn.GetProjectId());
+
+        [Fact]
+        public void ToString_ReturnsUriString()
+            => Assert.Equal(SentryDsn.Uri.ToString(), SentryDsn.ToString());
+
+        [Fact]
+        public void GetCaptureUrl()
+            => Assert.Equal(
+                expected: $"https://{Host}/api/{ProjectId}/store/",
+                actual: SentryDsn.GetCaptureUrl());
+
     }
 }

--- a/test/Pidget.Client.Test/SentryEventBuilderTests.cs
+++ b/test/Pidget.Client.Test/SentryEventBuilderTests.cs
@@ -173,6 +173,9 @@ namespace Pidget.Client.Test
                 .SetContexts(contexts);
 
             Assert.Equal(contexts, builder.Build().Contexts);
+            Assert.Equal(contexts.OperatingSystem, contexts["os"]);
+            Assert.Equal(contexts.Device, contexts["device"]);
+            Assert.Equal(contexts.Runtime, contexts["runtime"]);
         }
 
         private IEnumerable<KeyValuePair<string, TValue>> ToNamedPairs<TValue>(params object[] extraData)

--- a/test/Pidget.Client.Test/SentryEventBuilderTests.cs
+++ b/test/Pidget.Client.Test/SentryEventBuilderTests.cs
@@ -158,6 +158,23 @@ namespace Pidget.Client.Test
             Assert.Equal(data, builder.Build().Fingerprint);
         }
 
+        [Fact]
+        public void SetContexts()
+        {
+            var contexts = new ContextsData
+            {
+                OperatingSystem = new OperatingSystemData(),
+                Device = new DeviceData(),
+                Runtime = new RuntimeData()
+            };
+
+            var builder = new SentryEventBuilder()
+                .SetException(new Exception())
+                .SetContexts(contexts);
+
+            Assert.Equal(contexts, builder.Build().Contexts);
+        }
+
         private IEnumerable<KeyValuePair<string, TValue>> ToNamedPairs<TValue>(params object[] extraData)
         {
             if (extraData.Length % 2 != 0)


### PR DESCRIPTION
This PR solves #8 by adding support for contexts.

The contexts section of the event may contain any arbitrary data, there are however three special keys which gets extra processed:

- `"os"` - Operating system data
- `"device"` - Device data
- `"runtime"` - Run-time data

The Arbitrary data class has also been modified to conform to the full Dictionary API, this also allows for two-way data-binding.

