### PR TITLE
Increase writer buffer size from 64 to 1024

### DIFF
--- a/src/Pidget.Client/Serialization/JsonStreamSerializer.cs
+++ b/src/Pidget.Client/Serialization/JsonStreamSerializer.cs
@@ -9,6 +9,8 @@ namespace Pidget.Client.Serialization
 {
     public class JsonStreamSerializer
     {
+        public const int BufferSize = 1024;
+
         public Encoding Encoding { get; }
 
         private readonly JsonSerializer _serializer;
@@ -49,10 +51,9 @@ namespace Pidget.Client.Serialization
         }
 
         private StreamWriter CreateWriter(Stream stream)
-            => new StreamWriter(
-                stream: stream,
+            => new StreamWriter(stream,
                 encoding: Encoding,
-                bufferSize: 64,
+                bufferSize: BufferSize,
                 leaveOpen: true);
     }
 }


### PR DESCRIPTION
The previous text writer used a buffer size of 64, which would likely cause performance issues for bigger blobs. The previous buffer size was arbitrarily picked and was never revised afterwards.

The default size of the stream writer [is 1024](https://referencesource.microsoft.com/#mscorlib/system/io/streamwriter.cs,48), so I set it accordingly.

I'm a little confused to why there is no overload of `StreamWriter` which accepts `leaveOpen` but leaves out `bufferSize`. I also don't see any reason why `StreamWriter.DefaultBufferSize` is marked as `internal`.