### PR TITLE
Feature/use http x forwarded for

### DIFF
--- a/src/Pidget.AspNet/ExceptionReportingMiddleware.cs
+++ b/src/Pidget.AspNet/ExceptionReportingMiddleware.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Runtime.ExceptionServices;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Pidget.AspNet.Sanitizing;
 using Pidget.Client;
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
 
 namespace Pidget.AspNet
 {

--- a/src/Pidget.AspNet/ExceptionReportingOptions.cs
+++ b/src/Pidget.AspNet/ExceptionReportingOptions.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http;
-
 namespace Pidget.AspNet
 {
     public class ExceptionReportingOptions

--- a/src/Pidget.AspNet/RequestDataProvider.cs
+++ b/src/Pidget.AspNet/RequestDataProvider.cs
@@ -1,11 +1,9 @@
+using Microsoft.AspNetCore.Http;
+using Pidget.AspNet.Sanitizing;
+using Pidget.Client.DataModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.Extensions.Configuration;
-using Pidget.AspNet.Sanitizing;
-using Pidget.Client.DataModels;
 
 namespace Pidget.AspNet
 {

--- a/src/Pidget.AspNet/Sanitizing/NameValueSanitizer.cs
+++ b/src/Pidget.AspNet/Sanitizing/NameValueSanitizer.cs
@@ -1,7 +1,3 @@
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 

--- a/src/Pidget.AspNet/Sanitizing/RequestSanitizer.cs
+++ b/src/Pidget.AspNet/Sanitizing/RequestSanitizer.cs
@@ -1,10 +1,8 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace Pidget.AspNet.Sanitizing
 {

--- a/src/Pidget.AspNet/Setup/ClientFactory.cs
+++ b/src/Pidget.AspNet/Setup/ClientFactory.cs
@@ -1,7 +1,7 @@
-using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Pidget.Client;
+using System;
 
 namespace Pidget.AspNet.Setup
 {

--- a/src/Pidget.AspNet/Setup/SetupExtensions.cs
+++ b/src/Pidget.AspNet/Setup/SetupExtensions.cs
@@ -1,10 +1,8 @@
-using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Pidget.Client;
-using Pidget.Client.Http;
+using System;
 
 namespace Pidget.AspNet.Setup
 {

--- a/src/Pidget.AspNet/UserDataProvider.cs
+++ b/src/Pidget.AspNet/UserDataProvider.cs
@@ -52,7 +52,7 @@ namespace Pidget.AspNet
 
         private string GetXForwardedFor(HttpRequest request)
         {
-            request.Headers.TryGetValue("X-Forwarded-For",
+            request.Headers?.TryGetValue("X-Forwarded-For",
                 out var forwardedFor);
 
             return forwardedFor;

--- a/src/Pidget.AspNet/UserDataProvider.cs
+++ b/src/Pidget.AspNet/UserDataProvider.cs
@@ -57,6 +57,5 @@ namespace Pidget.AspNet
 
             return forwardedFor;
         }
-
     }
 }

--- a/src/Pidget.AspNet/UserDataProvider.cs
+++ b/src/Pidget.AspNet/UserDataProvider.cs
@@ -1,7 +1,7 @@
-using System;
-using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Pidget.Client.DataModels;
+using System;
+using System.Security.Claims;
 
 namespace Pidget.AspNet
 {

--- a/src/Pidget.AspNet/UserDataProvider.cs
+++ b/src/Pidget.AspNet/UserDataProvider.cs
@@ -23,10 +23,7 @@ namespace Pidget.AspNet
                     Email = GetEmail(context.User),
                 };
 
-            if (context.Connection != null)
-            {
-                user.IpAddress = GetIpAddress(context.Connection);
-            }
+            user.IpAddress = GetIpAddress(context);
 
             return user;
         }
@@ -49,7 +46,17 @@ namespace Pidget.AspNet
         public string GetId(ClaimsPrincipal user)
             => user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 
-        public string GetIpAddress(ConnectionInfo connection)
-            => connection.RemoteIpAddress?.ToString();
+        public string GetIpAddress(HttpContext http)
+            => GetXForwardedFor(http.Request)
+            ?? http.Connection?.RemoteIpAddress?.ToString();
+
+        private string GetXForwardedFor(HttpRequest request)
+        {
+            request.Headers.TryGetValue("X-Forwarded-For",
+                out var forwardedFor);
+
+            return forwardedFor;
+        }
+
     }
 }

--- a/src/Pidget.Client/DataModels/ExceptionData.cs
+++ b/src/Pidget.Client/DataModels/ExceptionData.cs
@@ -1,5 +1,5 @@
-using System;
 using Newtonsoft.Json;
+using System;
 
 namespace Pidget.Client.DataModels
 {

--- a/src/Pidget.Client/DataModels/FrameData.cs
+++ b/src/Pidget.Client/DataModels/FrameData.cs
@@ -1,8 +1,7 @@
+using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
-using Newtonsoft.Json;
 
 namespace Pidget.Client.DataModels
 {

--- a/src/Pidget.Client/DataModels/RequestData.cs
+++ b/src/Pidget.Client/DataModels/RequestData.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Pidget.Client.DataModels
 {

--- a/src/Pidget.Client/DataModels/SentryEventData.cs
+++ b/src/Pidget.Client/DataModels/SentryEventData.cs
@@ -1,6 +1,6 @@
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace Pidget.Client.DataModels
 {

--- a/src/Pidget.Client/DataModels/StackTraceData.cs
+++ b/src/Pidget.Client/DataModels/StackTraceData.cs
@@ -1,8 +1,8 @@
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using Newtonsoft.Json;
 
 namespace Pidget.Client.DataModels
 {

--- a/src/Pidget.Client/DataModels/UserData.cs
+++ b/src/Pidget.Client/DataModels/UserData.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using Newtonsoft.Json;
-
 namespace Pidget.Client.DataModels
 {
     public class UserData : ArbitraryData

--- a/src/Pidget.Client/Http/SentryAuthHeader.cs
+++ b/src/Pidget.Client/Http/SentryAuthHeader.cs
@@ -1,4 +1,3 @@
-
 using System.Collections.Generic;
 
 namespace Pidget.Client.Http

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -1,12 +1,11 @@
-using System;
-using System.IO;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Pidget.Client.DataModels;
 using Pidget.Client.Serialization;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 using static System.Threading.CancellationToken;
 

--- a/src/Pidget.Client/Http/SentryResponseProvider.cs
+++ b/src/Pidget.Client/Http/SentryResponseProvider.cs
@@ -1,12 +1,9 @@
+using Pidget.Client.Serialization;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Pidget.Client.DataModels;
-using Pidget.Client.Serialization;
 
 namespace Pidget.Client.Http
 {

--- a/src/Pidget.Client/Sentry.cs
+++ b/src/Pidget.Client/Sentry.cs
@@ -1,6 +1,5 @@
-using System.Text;
-using Newtonsoft.Json.Serialization;
 using Pidget.Client.Http;
+using System.Text;
 
 namespace Pidget.Client
 {

--- a/src/Pidget.Client/SentryClient.cs
+++ b/src/Pidget.Client/SentryClient.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Net.Http;
+﻿using Pidget.Client.DataModels;
+using System;
 using System.Threading.Tasks;
-using Pidget.Client.DataModels;
 
 namespace Pidget.Client
 {

--- a/src/Pidget.Client/SentryEventBuilder.cs
+++ b/src/Pidget.Client/SentryEventBuilder.cs
@@ -1,7 +1,6 @@
+using Pidget.Client.DataModels;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Pidget.Client.DataModels;
 
 namespace Pidget.Client
 {

--- a/src/Pidget.Client/SentryResponse.cs
+++ b/src/Pidget.Client/SentryResponse.cs
@@ -1,7 +1,5 @@
-using System.Net;
-using System.Net.Http;
 using Pidget.Client.DataModels;
-using Pidget.Client.Serialization;
+using System.Net;
 
 namespace Pidget.Client
 {

--- a/src/Pidget.Client/Serialization/JsonStreamSerializer.cs
+++ b/src/Pidget.Client/Serialization/JsonStreamSerializer.cs
@@ -1,6 +1,4 @@
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.IO;
 using System.Text;

--- a/test/Pidget.AspNet.Test/RequestDataProviderTests.cs
+++ b/test/Pidget.AspNet.Test/RequestDataProviderTests.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/Pidget.AspNet.Test/RequestDataProviderTests.cs
+++ b/test/Pidget.AspNet.Test/RequestDataProviderTests.cs
@@ -131,7 +131,7 @@ namespace Pidget.AspNet.Test
         }
 
         [Fact]
-        public void NoHeaders_ReturnsEmpty()
+        public void NoHeaders_ReturnsNull()
         {
             var requestMock = new Mock<HttpRequest>();
 
@@ -140,7 +140,7 @@ namespace Pidget.AspNet.Test
 
             var headers = RequestData.GetHeaders(requestMock.Object);
 
-            // Assert.Empty(headers);
+            Assert.Null(headers);
         }
 
         [Theory, InlineData("application/x-www-form-urlencoded")]

--- a/test/Pidget.AspNet.Test/UserDataProviderTests.cs
+++ b/test/Pidget.AspNet.Test/UserDataProviderTests.cs
@@ -34,8 +34,7 @@ namespace Pidget.AspNet
             Assert.Equal(email, UserDataProvider.Default.GetEmail(user));
         }
 
-        [Theory]
-        [InlineData("user")]
+        [Theory, InlineData("user")]
         public void GetUserName_ReturnsIdentityName(string userName)
         {
             var identityMock = new Mock<IIdentity>();
@@ -51,8 +50,7 @@ namespace Pidget.AspNet
             identityMock.Verify();
         }
 
-        [Theory]
-        [InlineData("user")]
+        [Theory, InlineData("user")]
         public void GetUserName_NoIdentityFallbacksToNameClaim(string userName)
         {
             var user = MockUser(Tuple.Create(ClaimTypes.Name, userName));
@@ -60,8 +58,7 @@ namespace Pidget.AspNet
             Assert.Equal(userName, UserDataProvider.Default.GetUserName(user));
         }
 
-        [Theory]
-        [InlineData("user")]
+        [Theory, InlineData("user")]
         public void GetUserName_NoIdentityNameFallbacksToNameClaim(
             string userName)
         {

--- a/test/Pidget.AspNet.Test/UserDataProviderTests.cs
+++ b/test/Pidget.AspNet.Test/UserDataProviderTests.cs
@@ -1,12 +1,10 @@
+using Microsoft.AspNetCore.Http;
+using Moq;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Security.Principal;
-using Microsoft.AspNetCore.Http;
-using Moq;
-using Pidget.Client.DataModels;
 using Xunit;
 
 namespace Pidget.AspNet
@@ -21,7 +19,7 @@ namespace Pidget.AspNet
         [Theory, InlineData("1")]
         public void GetId_UsesNameIdentifierClaim(string id)
         {
-            var user = MockUser(Tuple.Create(ClaimTypes.NameIdentifier, id));
+            var user = MakeUser(Tuple.Create(ClaimTypes.NameIdentifier, id));
 
             Assert.Equal(id, UserDataProvider.Default.GetId(user));
         }
@@ -29,7 +27,7 @@ namespace Pidget.AspNet
         [Theory, InlineData("foo@bar")]
         public void GetEmail_ReturnsEmailClaim(string email)
         {
-            var user = MockUser(Tuple.Create(ClaimTypes.Email, email));
+            var user = MakeUser(Tuple.Create(ClaimTypes.Email, email));
 
             Assert.Equal(email, UserDataProvider.Default.GetEmail(user));
         }
@@ -53,7 +51,7 @@ namespace Pidget.AspNet
         [Theory, InlineData("user")]
         public void GetUserName_NoIdentityFallbacksToNameClaim(string userName)
         {
-            var user = MockUser(Tuple.Create(ClaimTypes.Name, userName));
+            var user = MakeUser(Tuple.Create(ClaimTypes.Name, userName));
 
             Assert.Equal(userName, UserDataProvider.Default.GetUserName(user));
         }
@@ -82,21 +80,29 @@ namespace Pidget.AspNet
         [Theory, InlineData("0.0.0.0")]
         public void GetIpAddress(string ipAddress)
         {
-            var connectionMock = new Mock<ConnectionInfo>();
+            var connMock = new Mock<ConnectionInfo>();
 
-            connectionMock.SetupGet(c => c.RemoteIpAddress)
+            connMock.SetupGet(c => c.RemoteIpAddress)
                 .Returns(IPAddress.Parse(ipAddress))
                 .Verifiable();
+
+            var reqMock = new Mock<HttpRequest>();
+
+            reqMock.SetupGet(r => r.Headers)
+                .Returns(new HeaderDictionary());
 
             var httpMock = new Mock<HttpContext>();
 
             httpMock.SetupGet(c => c.Connection)
-                .Returns(connectionMock.Object);
+                .Returns(connMock.Object);
+
+            httpMock.SetupGet(c => c.Request)
+                .Returns(reqMock.Object);
 
             Assert.Equal(ipAddress,
                 UserDataProvider.Default.GetIpAddress(httpMock.Object));
 
-            connectionMock.Verify();
+            connMock.Verify();
         }
 
         [Theory, InlineData("1.1.1.1", "0.0.0.0")]
@@ -107,6 +113,7 @@ namespace Pidget.AspNet
             headers.Add("X-Forwarded-For", xForwardedFor);
 
             var reqMock = new Mock<HttpRequest>();
+
             reqMock.SetupGet(r => r.Headers)
                 .Returns(headers);
 
@@ -135,60 +142,67 @@ namespace Pidget.AspNet
             string email,
             string ipAddress)
         {
-            var user = MockUser(Tuple.Create(ClaimTypes.NameIdentifier, id),
+            var user = MakeUser(Tuple.Create(ClaimTypes.NameIdentifier, id),
                 Tuple.Create(ClaimTypes.Name, userName),
                 Tuple.Create(ClaimTypes.Email, email));
 
-            var connectionMock = new Mock<ConnectionInfo>();
+            var connMock = new Mock<ConnectionInfo>();
 
-            connectionMock.SetupGet(c => c.RemoteIpAddress)
+            connMock.SetupGet(c => c.RemoteIpAddress)
                 .Returns(ipAddress != null
                     ? IPAddress.Parse(ipAddress)
                     : null)
                 .Verifiable();
 
-            var contextMock = new Mock<HttpContext>();
+            var httpMock = new Mock<HttpContext>();
 
-            contextMock.SetupGet(c => c.User)
+            httpMock.SetupGet(c => c.User)
                 .Returns(user)
                 .Verifiable();
 
-            contextMock.SetupGet(c => c.Connection)
-                .Returns(connectionMock.Object)
+            httpMock.SetupGet(c => c.Connection)
+                .Returns(connMock.Object)
                 .Verifiable();
 
-            var data = UserDataProvider.Default.GetUserData(contextMock.Object);
+            httpMock.SetupGet(c => c.Request)
+                .Returns(Mock.Of<HttpRequest>());
+
+            var data = UserDataProvider.Default.GetUserData(httpMock.Object);
 
             Assert.Equal(id, data.Id);
             Assert.Equal(userName, data.UserName);
             Assert.Equal(email, data.Email);
             Assert.Equal(ipAddress, data.IpAddress);
 
-            connectionMock.Verify();
-            contextMock.Verify();
+            connMock.Verify();
+            httpMock.Verify();
         }
 
         [Fact]
-        public void GetUserData_NoClaims_NoConnection()
+        public void GetUserData_NoClaims()
         {
-            var user = MockUser();
-            var contextMock = new Mock<HttpContext>();
+            var user = MakeUser();
 
-            contextMock.SetupGet(c => c.User)
+            var httpMock = new Mock<HttpContext>();
+
+            httpMock.SetupGet(c => c.User)
                 .Returns(user)
                 .Verifiable();
 
-            var data = UserDataProvider.Default.GetUserData(contextMock.Object);
+            httpMock.SetupGet(r => r.Request)
+                .Returns(Mock.Of<HttpRequest>());
+
+            var data = UserDataProvider.Default.GetUserData(httpMock.Object);
 
             Assert.Null(data.Id);
             Assert.Null(data.UserName);
             Assert.Null(data.Email);
             Assert.Null(data.IpAddress);
 
-            contextMock.Verify();
+            httpMock.Verify();
         }
 
-        public static ClaimsPrincipal MockUser(params Tuple<string, string>[] claims)
+        public static ClaimsPrincipal MakeUser(params Tuple<string, string>[] claims)
         {
             var identity = new ClaimsIdentity(claims
                 .Select(c => new Claim(c.Item1, c.Item2)));


### PR DESCRIPTION
In response to #18. 

The middle-ware will now prefer the HTTP header `X-Forwarded-For` commonly used by various reverse-proxy solution (e.g nginx).