### PR TITLE
Add shell script for tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+dotnet build
+
+for f in test/*
+do
+   cd $f
+
+   dotnet test --no-build
+done


### PR DESCRIPTION
I've recently gone over to Ubuntu, so I've added a shell script for tests `test.sh`.
I wanted to add shell-scripts for OpenCover, but it currently does not support running on linux systems.