### PR TITLE
Support empty DSN

### DIFF
--- a/src/Pidget.AspNet/Setup/ClientFactory.cs
+++ b/src/Pidget.AspNet/Setup/ClientFactory.cs
@@ -12,9 +12,12 @@ namespace Pidget.AspNet.Setup
             var optionsAccessor = serviceProvider
                 .GetRequiredService<IOptions<ExceptionReportingOptions>>();
 
-            var dsn = Dsn.Create(optionsAccessor.Value.Dsn);
-
-            return Sentry.CreateClient(dsn);
+            return Sentry.CreateClient(GetDsn(optionsAccessor.Value));
         }
+
+        private static Dsn GetDsn(ExceptionReportingOptions options)
+            => !string.IsNullOrEmpty(options.Dsn)
+                ? Dsn.Create(options.Dsn)
+                : null;
     }
 }

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -13,12 +13,14 @@ namespace Pidget.Client.Http
 {
     public class SentryHttpClient : SentryClient, IDisposable
     {
-        public static TimeSpan Timeout { get; } = TimeSpan.FromSeconds(3);
+        public static TimeSpan Timeout { get; }
+            = TimeSpan.FromSeconds(3);
 
         public static JsonSerializer JsonSerializer { get; }
             = GetJsonSerializer();
 
-        public static string UserAgent => string.Join("/", Name, Version);
+        public static string UserAgent { get; }
+            = string.Join("/", Name, Version);
 
         private static readonly JsonStreamSerializer _streamSerializer
             = new JsonStreamSerializer(

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -50,10 +50,15 @@ namespace Pidget.Client.Http
         public override async Task<SentryResponse> SendEventAsync(
             SentryEventData eventData)
         {
+            if (!IsEnabled)
+            {
+                return SentryResponse.Empty;
+            }
+
             using (var stream = _streamSerializer.Serialize(eventData))
             {
                 var httpResponse = await _sender
-                    .SendAsync(GetRequest(stream), None)
+                    .SendAsync(ComposeMessage(stream), None)
                     .ConfigureAwait(false);
 
                 var responseProvider = new SentryResponseProvider(_streamSerializer);
@@ -76,7 +81,7 @@ namespace Pidget.Client.Http
         public static SentryHttpClient CreateDefault(Dsn dsn)
             => new SentryHttpClient(dsn, CreateSender());
 
-        private HttpRequestMessage GetRequest(Stream stream)
+        private HttpRequestMessage ComposeMessage(Stream stream)
         {
             var request = new HttpRequestMessage(HttpMethod.Post,
                 Dsn.GetCaptureUrl());

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -69,7 +69,7 @@ namespace Pidget.Client.Http
 
         public void Dispose() => _sender.Dispose();
 
-        public static HttpMessageInvoker CreateSender()
+        public static HttpClient CreateHttpClient()
         {
             var client = new HttpClient { Timeout = Timeout };
 
@@ -78,8 +78,8 @@ namespace Pidget.Client.Http
             return client;
         }
 
-        public static SentryHttpClient CreateDefault(Dsn dsn)
-            => new SentryHttpClient(dsn, CreateSender());
+        public static SentryHttpClient Default(Dsn dsn)
+            => new SentryHttpClient(dsn, CreateHttpClient());
 
         private HttpRequestMessage ComposeMessage(Stream stream)
         {

--- a/src/Pidget.Client/Sentry.cs
+++ b/src/Pidget.Client/Sentry.cs
@@ -15,6 +15,6 @@ namespace Pidget.Client
             = new UTF8Encoding(false, false);
 
         public static SentryClient CreateClient(Dsn dsn)
-            => SentryHttpClient.CreateDefault(dsn);
+            => SentryHttpClient.Default(dsn);
     }
 }

--- a/src/Pidget.Client/Sentry.cs
+++ b/src/Pidget.Client/Sentry.cs
@@ -7,8 +7,6 @@ namespace Pidget.Client
     {
         public const string CurrentProtocolVersion = "7";
 
-        public const string DefaultLoggerName = "root";
-
         internal const string CSharpPlatformIdentifier = "csharp";
 
         public static Encoding ApiEncoding { get; }

--- a/src/Pidget.Client/SentryClient.cs
+++ b/src/Pidget.Client/SentryClient.cs
@@ -12,12 +12,10 @@ namespace Pidget.Client
 
         public Dsn Dsn { get; }
 
-        protected SentryClient(Dsn dsn)
-        {
-            Assert.ArgumentNotNull(dsn, nameof(dsn));
+        public bool IsEnabled => Dsn != null;
 
-            Dsn = dsn;
-        }
+        protected SentryClient(Dsn dsn)
+            => Dsn = dsn;
 
         public Task<SentryResponse> CaptureAsync(
             Action<SentryEventBuilder> builderAccessor)

--- a/src/Pidget.Client/SentryResponse.cs
+++ b/src/Pidget.Client/SentryResponse.cs
@@ -5,6 +5,8 @@ namespace Pidget.Client
 {
     public class SentryResponse : ArbitraryData
     {
+        public static SentryResponse Empty => new SentryResponse();
+
         public string EventId
         {
             get => this["id"] as string;

--- a/test/Pidget.AspNet.Test/Setup/ClientFactoryTests.cs
+++ b/test/Pidget.AspNet.Test/Setup/ClientFactoryTests.cs
@@ -41,6 +41,24 @@ namespace Pidget.AspNet.Setup
             AssertAreDefaultSanitationOptions(Options.Sanitation);
         }
 
+        [Theory, InlineData(null), InlineData("")]
+        public void NoDsn_CreatesDisabledClient(string dsn)
+        {
+            var providerMock = new Mock<IServiceProvider>();
+            var optionsMock = new Mock<IOptions<ExceptionReportingOptions>>();
+
+            optionsMock.SetupGet(o => o.Value)
+                .Returns(new ExceptionReportingOptions { Dsn = dsn });
+
+            providerMock.Setup(sp => sp.GetService(typeof(IOptions<ExceptionReportingOptions>)))
+                .Returns(optionsMock.Object);
+
+            var client = ClientFactory.CreateClient(providerMock.Object);
+
+            Assert.Null(client.Dsn);
+            Assert.False(client.IsEnabled);
+        }
+
         private void AssertAreDefaultSanitationOptions(SanitationOptions sanitation)
         {
             var defaults = SanitationOptions.Default;

--- a/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
+++ b/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
@@ -30,11 +30,6 @@ namespace Pidget.Client.Test
             => Assert.Throws<ArgumentNullException>(()
                 => new SentryHttpClient(DsnTests.SentryDsn, null));
 
-        [Fact]
-        public void RequiresDsn()
-            => Assert.Throws<ArgumentNullException>(()
-                => new SentryHttpClient(null,
-                    SentryHttpClient.CreateSender()));
 
         [Fact]
         public void HasExpectedUserAgent()

--- a/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
+++ b/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
@@ -34,7 +34,7 @@ namespace Pidget.Client.Test
         [Fact]
         public void Sender_HasExpectedUserAgent()
         {
-            var httpClient = SentryHttpClient.CreateSender() as HttpClient;
+            var httpClient = SentryHttpClient.CreateHttpClient();
 
             Assert.Equal(SentryHttpClient.UserAgent,
                 httpClient.DefaultRequestHeaders.UserAgent.ToString());
@@ -65,6 +65,24 @@ namespace Pidget.Client.Test
         }
 
         [Fact]
+        public async Task DisabledClient_ReturnsEmptyResponse()
+        {
+            var senderMock = new Mock<HttpClient>();
+
+            var client = new SentryHttpClient(null, senderMock.Object);
+
+            var response = await client.SendEventAsync(
+                new SentryEventData());
+
+            senderMock.Verify(s => s.SendAsync(It.IsAny<HttpRequestMessage>(),
+                It.IsAny<CancellationToken>()),
+                Times.Never());
+
+            Assert.NotNull(response);
+            Assert.Null(response.EventId);
+        }
+
+        [Fact]
         public void DisposesSender()
         {
             var sender = new TestSender(new HttpClientHandler());
@@ -80,7 +98,7 @@ namespace Pidget.Client.Test
         [Fact]
         public void CreateDefault()
             => Assert.NotNull(
-                SentryHttpClient.CreateDefault(DsnTests.SentryDsn));
+                SentryHttpClient.Default(DsnTests.SentryDsn));
 
         [Fact(Skip = "Manual testing only")]
         public async Task SendException_ReturnsEventId()

--- a/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
+++ b/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
@@ -32,7 +32,7 @@ namespace Pidget.Client.Test
 
 
         [Fact]
-        public void HasExpectedUserAgent()
+        public void Sender_HasExpectedUserAgent()
         {
             var httpClient = SentryHttpClient.CreateSender() as HttpClient;
 

--- a/test/Pidget.Client.Test/SentryClientTests.cs
+++ b/test/Pidget.Client.Test/SentryClientTests.cs
@@ -9,11 +9,6 @@ namespace Pidget.Client.Test
         public static readonly Dsn Dsn = DsnTests.SentryDsn;
 
         [Fact]
-        public void ThrowsFullNullDsn()
-            => Assert.Throws<ArgumentNullException>(() =>
-                new TestableSentryClient(null, _ => null));
-
-        [Fact]
         public async Task Capture_InvokesSend()
         {
             // Arrange


### PR DESCRIPTION
In response to #22. Empty DSN's should be a valid option.

For clarity, a `IsEnabled`-property has been added to the client.