### PR TITLE
Honor Sentry's 429 Retry-After Header

### DIFF
--- a/examples/Pidget.AspNetExample/OnExceptionMiddleware.cs
+++ b/examples/Pidget.AspNetExample/OnExceptionMiddleware.cs
@@ -19,26 +19,26 @@ namespace Pidget.AspNetExample
             Options = optionsAccessor.Value;
         }
 
-        public async Task Invoke(HttpContext context)
+        public async Task Invoke(HttpContext http)
         {
             try
             {
-                await _next(context);
+                await _next(http);
             }
             catch (Exception ex)
             {
-                context.Response.StatusCode = 200;
-                context.Response.ContentType = "text/plain";
+                http.Response.StatusCode = 200;
+                http.Response.ContentType = "text/plain";
 
-                await WriteExceptionAsync(context, ex);
+                await WriteExceptionAsync(http, ex);
             }
         }
 
-        public async Task WriteExceptionAsync(HttpContext context, Exception ex)
+        public async Task WriteExceptionAsync(HttpContext http, Exception ex)
         {
-            await context.Response.WriteAsync($"{ex}\r\n\r\n");
-            await context.Response.WriteAsync(
-                $"Sentry event ID: {context.Items[ExceptionReportingMiddleware.EventIdKey]}");
+            await http.Response.WriteAsync($"{ex}\r\n\r\n");
+            await http.Response.WriteAsync(
+                $"Sentry event ID: {http.Items[ExceptionReportingMiddleware.EventIdKey]}");
         }
     }
 }

--- a/src/Pidget.AspNet/ExceptionReportingMiddleware.cs
+++ b/src/Pidget.AspNet/ExceptionReportingMiddleware.cs
@@ -71,7 +71,7 @@ namespace Pidget.AspNet
         }
 
         private bool IsTooManyRequests(SentryResponse response)
-            => response.HttpStatusCode == (HttpStatusCode)429
+            => response.StatusCode == 429
             && response.RetryAfter != null;
 
         private SentryEventData BuildEventData(Exception ex, HttpContext http)

--- a/src/Pidget.AspNet/RateLimiter.cs
+++ b/src/Pidget.AspNet/RateLimiter.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Pidget.AspNet
+{
+    public class RateLimiter
+    {
+        private DateTimeOffset _retryAfter;
+
+        public void LimitFor(TimeSpan duration)
+            => _retryAfter = DateTimeOffset.UtcNow + duration;
+
+        public bool IsRateLimited(DateTimeOffset when)
+            => when < _retryAfter;
+    }
+}

--- a/src/Pidget.AspNet/Setup/SetupExtensions.cs
+++ b/src/Pidget.AspNet/Setup/SetupExtensions.cs
@@ -17,7 +17,8 @@ namespace Pidget.AspNet.Setup
             this IServiceCollection services,
             Action<ExceptionReportingOptions> setup)
             => services.Configure<ExceptionReportingOptions>(setup)
-                .AddScoped<SentryClient>(ClientFactory.CreateClient);
+                .AddScoped<SentryClient>(ClientFactory.CreateClient)
+                .AddSingleton<RateLimiter>();
 
         public static IApplicationBuilder UsePidgetMiddleware(
             this IApplicationBuilder builder)

--- a/src/Pidget.AspNet/UserDataProvider.cs
+++ b/src/Pidget.AspNet/UserDataProvider.cs
@@ -50,9 +50,9 @@ namespace Pidget.AspNet
             => GetXForwardedFor(http.Request)
             ?? http.Connection?.RemoteIpAddress?.ToString();
 
-        private string GetXForwardedFor(HttpRequest request)
+        private string GetXForwardedFor(HttpRequest req)
         {
-            request.Headers?.TryGetValue("X-Forwarded-For",
+            req.Headers?.TryGetValue("X-Forwarded-For",
                 out var forwardedFor);
 
             return forwardedFor;

--- a/src/Pidget.AspNet/UserDataProvider.cs
+++ b/src/Pidget.AspNet/UserDataProvider.cs
@@ -10,20 +10,20 @@ namespace Pidget.AspNet
         public static UserDataProvider Default { get; }
              = new UserDataProvider();
 
-        public UserData GetUserData(HttpContext context)
+        public UserData GetUserData(HttpContext http)
         {
-            AssertContextNotNull(context);
+            AssertContextNotNull(http);
 
-            var user = context.User == null
+            var user = http.User == null
                 ? new UserData()
                 : new UserData
                 {
-                    Id = GetId(context.User),
-                    UserName = GetUserName(context.User),
-                    Email = GetEmail(context.User),
+                    Id = GetId(http.User),
+                    UserName = GetUserName(http.User),
+                    Email = GetEmail(http.User),
                 };
 
-            user.IpAddress = GetIpAddress(context);
+            user.IpAddress = GetIpAddress(http);
 
             return user;
         }

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -83,18 +83,18 @@ namespace Pidget.Client.Http
 
         private HttpRequestMessage ComposeMessage(Stream stream)
         {
-            var request = new HttpRequestMessage(HttpMethod.Post,
+            var message = new HttpRequestMessage(HttpMethod.Post,
                 Dsn.GetCaptureUrl());
 
-            AddSentryAuthHeader(request);
+            AddSentryAuthHeader(message);
 
-            request.Content = GetContent(stream);
+            message.Content = GetContent(stream);
 
-            return request;
+            return message;
         }
 
-        private void AddSentryAuthHeader(HttpRequestMessage request)
-            => request.Headers.Add(SentryAuthHeader.Name,
+        private void AddSentryAuthHeader(HttpRequestMessage message)
+            => message.Headers.Add(SentryAuthHeader.Name,
                 SentryAuthHeader.GetValues(
                     SentryAuth.Issue(this, DateTimeOffset.Now)));
 

--- a/src/Pidget.Client/Http/SentryResponseProvider.cs
+++ b/src/Pidget.Client/Http/SentryResponseProvider.cs
@@ -45,7 +45,7 @@ namespace Pidget.Client.Http
                 var responseData = Serializer
                     .Deserialize<SentryResponse>(body);
 
-                responseData.HttpStatusCode = response.StatusCode;
+                responseData.StatusCode = (int)response.StatusCode;
                 responseData.SentryError = GetSentryError(response);
                 responseData.RetryAfter = GetRetryAfter(response);
 
@@ -56,7 +56,7 @@ namespace Pidget.Client.Http
         private SentryResponse GetErrorResponse(HttpResponseMessage response)
             => new SentryResponse
             {
-                HttpStatusCode = response.StatusCode,
+                StatusCode = (int)response.StatusCode,
                 SentryError = GetSentryError(response),
                 RetryAfter = GetRetryAfter(response)
             };

--- a/src/Pidget.Client/SentryResponse.cs
+++ b/src/Pidget.Client/SentryResponse.cs
@@ -1,5 +1,6 @@
 using Pidget.Client.DataModels;
 using System.Net;
+using System;
 
 namespace Pidget.Client
 {
@@ -16,5 +17,7 @@ namespace Pidget.Client
         public string SentryError { get; set; }
 
         public HttpStatusCode HttpStatusCode { get; set; }
+
+        public TimeSpan? RetryAfter { get; set; }
     }
 }

--- a/src/Pidget.Client/SentryResponse.cs
+++ b/src/Pidget.Client/SentryResponse.cs
@@ -16,7 +16,7 @@ namespace Pidget.Client
 
         public string SentryError { get; set; }
 
-        public HttpStatusCode HttpStatusCode { get; set; }
+        public int StatusCode { get; set; }
 
         public TimeSpan? RetryAfter { get; set; }
     }

--- a/test/Pidget.AspNet.Test/ExceptionReportingMiddlewareTests.cs
+++ b/test/Pidget.AspNet.Test/ExceptionReportingMiddlewareTests.cs
@@ -193,7 +193,7 @@ namespace Pidget.AspNet.Test
                 .SendEventAsync(It.IsAny<SentryEventData>()))
                 .ReturnsAsync(new SentryResponse
                 {
-                    HttpStatusCode = (HttpStatusCode)429,
+                    StatusCode = 429,
                     RetryAfter = retryAfter,
                 })
                 .Verifiable();

--- a/test/Pidget.AspNet.Test/ExceptionReportingMiddlewareTests.cs
+++ b/test/Pidget.AspNet.Test/ExceptionReportingMiddlewareTests.cs
@@ -232,6 +232,7 @@ namespace Pidget.AspNet.Test
             SentryClient client)
             => new ExceptionReportingMiddleware(next,
                 Options.Create(ExceptionReportingOptions),
-                client);
+                client,
+                new RateLimiter());
     }
 }

--- a/test/Pidget.AspNet.Test/ExceptionReportingMiddlewareTests.cs
+++ b/test/Pidget.AspNet.Test/ExceptionReportingMiddlewareTests.cs
@@ -16,7 +16,8 @@ namespace Pidget.AspNet.Test
 {
     public class ExceptionReportingMiddlewareTests
     {
-        public RequestDelegate Next_Throw = _ => throw new InvalidOperationException();
+        public RequestDelegate Next_Throw = _ =>
+            throw new InvalidOperationException("Hey, look at me!");
 
         public RequestDelegate Next_Noop = _ => Task.CompletedTask;
 
@@ -168,6 +169,63 @@ namespace Pidget.AspNet.Test
                 () => middleware.Invoke(httpMock.Object));
 
             clientMock.Verify();
+        }
+
+        [Fact]
+        public async Task Honors429RetryAfter()
+        {
+            var reqMock = new Mock<HttpRequest>();
+
+            var httpMock = new Mock<HttpContext>();
+
+            httpMock.Setup(m => m.Items)
+                .Returns(new Dictionary<object, object>());
+
+            httpMock.SetupGet(c => c.Request)
+                .Returns(reqMock.Object);
+
+            var clientMock = new Mock<SentryClient>(
+                Dsn.Create(ExceptionReportingOptions.Dsn));
+
+            var retryAfter = TimeSpan.FromMilliseconds(100);
+
+            clientMock.Setup(m => m
+                .SendEventAsync(It.IsAny<SentryEventData>()))
+                .ReturnsAsync(new SentryResponse
+                {
+                    HttpStatusCode = (HttpStatusCode)429,
+                    RetryAfter = retryAfter,
+                })
+                .Verifiable();
+
+            var middleware = CreateMiddleware(Next_Throw, clientMock.Object);
+
+            // Invoke once, get "RetryAfter"
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => middleware.Invoke(httpMock.Object));
+
+            // Invoke twice: reject
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => middleware.Invoke(httpMock.Object));
+
+            clientMock.Verify(m => m
+                .SendEventAsync(It.IsAny<SentryEventData>()),
+                Times.Once());
+
+            // Delay for requested period
+
+            await Task.Delay(retryAfter);
+
+            // Inoke again, responds with 429, but sends request.
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => middleware.Invoke(httpMock.Object));
+
+            clientMock.Verify(m => m
+                .SendEventAsync(It.IsAny<SentryEventData>()),
+                Times.Exactly(2));
         }
 
         public ExceptionReportingMiddleware CreateMiddleware(RequestDelegate next,

--- a/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
+++ b/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
@@ -28,6 +28,22 @@ namespace Pidget.AspNet.Setup
         }
 
         [Fact]
+        public void AddPidgetMiddleware_AddsRateLimiter()
+        {
+            var servicesMock = new Mock<IServiceCollection>();
+
+            servicesMock.Setup(m => m
+                .Add(It.Is<ServiceDescriptor>(s
+                    => typeof(RateLimiter) == s.ServiceType
+                    && s.Lifetime == ServiceLifetime.Singleton)))
+                .Verifiable();
+
+            servicesMock.Object.AddPidgetMiddleware(_ => {});
+
+            servicesMock.Verify();
+        }
+
+        [Fact]
         public void AddPidgetMiddleware_Setup_AddsOptions()
         {
             var servicesMock = new Mock<IServiceCollection>();

--- a/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
+++ b/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
@@ -59,7 +59,7 @@ namespace Pidget.Client.Test
 
             senderMock.Verify();
 
-            Assert.Equal(HttpStatusCode.OK, response.HttpStatusCode);
+            Assert.Equal(200, response.StatusCode);
             Assert.NotNull(response.EventId);
             Assert.Null(response.SentryError);
         }

--- a/test/Pidget.Client.Test/SentryResponseProviderTests.cs
+++ b/test/Pidget.Client.Test/SentryResponseProviderTests.cs
@@ -55,7 +55,7 @@ namespace Pidget.Client.Http
             var sentryResponse = await ResponseProvider
                 .GetResponseAsync(response);
 
-            Assert.Equal(response.StatusCode, sentryResponse.HttpStatusCode);
+            Assert.Equal(200, sentryResponse.StatusCode);
             Assert.Null(sentryResponse.EventId);
         }
 
@@ -75,7 +75,7 @@ namespace Pidget.Client.Http
             var sentryResponse = await ResponseProvider
                 .GetResponseAsync(response);
 
-            Assert.Equal(response.StatusCode, sentryResponse.HttpStatusCode);
+            Assert.Equal(200, sentryResponse.StatusCode);
             Assert.Null(sentryResponse.EventId);
         }
 
@@ -91,7 +91,7 @@ namespace Pidget.Client.Http
             var sentryResponse = await ResponseProvider
                 .GetResponseAsync(response);
 
-            Assert.Equal(statusCode, sentryResponse.HttpStatusCode);
+            Assert.Equal(200, sentryResponse.StatusCode);
         }
 
         [Theory, InlineData("foo")]

--- a/test/Pidget.Client.Test/SentryResponseProviderTests.cs
+++ b/test/Pidget.Client.Test/SentryResponseProviderTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 using System.Net.Http.Headers;
 using Moq;
 using System.IO;
+using System;
 
 namespace Pidget.Client.Http
 {
@@ -107,6 +108,48 @@ namespace Pidget.Client.Http
             var sentryResponse = await ResponseProvider.GetResponseAsync(response);
 
             Assert.Equal(error, sentryResponse.SentryError);
+        }
+
+        [Theory, InlineData(10)]
+        public async Task RetryAfter_Delta(int deltaSeconds)
+        {
+            var response = new HttpResponseMessage
+            {
+                StatusCode = (HttpStatusCode)429,
+                ReasonPhrase = "Too Many Requests",
+                Content = new StringContent("{ }"),
+            };
+
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(
+                TimeSpan.FromSeconds(deltaSeconds));
+
+            var sentryResponse = await ResponseProvider.GetResponseAsync(response);
+
+            Assert.Equal(
+                expected: deltaSeconds,
+                actual: sentryResponse.RetryAfter.Value.TotalSeconds);
+        }
+
+        [Theory, InlineData(10)]
+        public async Task RetryAfter_Date(int deltaSeconds)
+        {
+            var response = new HttpResponseMessage
+            {
+                StatusCode = (HttpStatusCode)429,
+                ReasonPhrase = "Too Many Requests",
+                Content = new StringContent("{ }"),
+            };
+
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(
+                DateTimeOffset.UtcNow.AddSeconds(deltaSeconds));
+
+            var sentryResponse = await ResponseProvider.GetResponseAsync(response);
+
+            var actualSeconds = sentryResponse.RetryAfter.Value.TotalSeconds;
+
+            Assert.Equal(
+                expected: deltaSeconds,
+                actual: Math.Round(actualSeconds));
         }
     }
 }


### PR DESCRIPTION
A `RetryAfter` property has been added to the response model, and the ASP.NET middleware has been updated to honor it The middleware will (pretty stupidly), just return `null`, if rate limiting occurs. However, this will likely be solved when #24 and #21 is implemented.
