### PR TITLE
Fix dependency-injection problems

### DIFF
--- a/src/Pidget.AspNet/SentryMiddleware.cs
+++ b/src/Pidget.AspNet/SentryMiddleware.cs
@@ -13,11 +13,11 @@ namespace Pidget.AspNet
     {
         public SentryOptions Options { get; }
 
-        private readonly RateLimit _rateLimit;
-
         private readonly RequestDelegate _next;
 
         private readonly SentryClient _sentryClient;
+
+        private readonly RateLimit _rateLimit;
 
         public SentryMiddleware(RequestDelegate next,
             IConfigureOptions<SentryOptions> optionSetup,
@@ -49,7 +49,7 @@ namespace Pidget.AspNet
             {
                 await CaptureAsync(ex, http);
 
-                SilentlyRethrow(ex);
+                ForwardException(ex);
             }
         }
 
@@ -96,7 +96,7 @@ namespace Pidget.AspNet
                 .SetRequestData(GetRequestData(http.Request));
 
         private UserData GetUserData(HttpContext http)
-            => UserDataProvider.Default.GetUserData(http);
+            => UserDataProvider.GetUserData(http);
 
         private RequestData GetRequestData(HttpRequest req)
         {
@@ -110,7 +110,7 @@ namespace Pidget.AspNet
         /// Re-throws the provided exception without adding to the stack trace.
         /// </summary>
         /// <param name="ex">The exception to re-throw.</param>
-        private static void SilentlyRethrow(Exception ex)
+        private static void ForwardException(Exception ex)
             => ExceptionDispatchInfo.Capture(ex).Throw();
     }
 }

--- a/src/Pidget.AspNet/Setup/ClientFactory.cs
+++ b/src/Pidget.AspNet/Setup/ClientFactory.cs
@@ -9,10 +9,19 @@ namespace Pidget.AspNet.Setup
     {
         public static SentryClient CreateClient(IServiceProvider serviceProvider)
         {
-            var optionsAccessor = serviceProvider
-                .GetRequiredService<IOptions<SentryOptions>>();
+            var options = GetOptions(serviceProvider);
 
-            return Sentry.CreateClient(GetDsn(optionsAccessor.Value));
+            return Sentry.CreateClient(GetDsn(options));
+        }
+
+        private static SentryOptions GetOptions(IServiceProvider provider)
+        {
+            var options = new SentryOptions();
+            var configure = provider.GetRequiredService<IConfigureOptions<SentryOptions>>();
+
+            configure.Configure(options);
+
+            return options;
         }
 
         private static Dsn GetDsn(SentryOptions options)

--- a/src/Pidget.AspNet/Setup/ClientFactory.cs
+++ b/src/Pidget.AspNet/Setup/ClientFactory.cs
@@ -17,9 +17,10 @@ namespace Pidget.AspNet.Setup
         private static SentryOptions GetOptions(IServiceProvider provider)
         {
             var options = new SentryOptions();
-            var configure = provider.GetRequiredService<IConfigureOptions<SentryOptions>>();
+            var setup = provider
+                .GetRequiredService<IConfigureOptions<SentryOptions>>();
 
-            configure.Configure(options);
+            setup.Configure(options);
 
             return options;
         }

--- a/src/Pidget.AspNet/Setup/SetupExtensions.cs
+++ b/src/Pidget.AspNet/Setup/SetupExtensions.cs
@@ -12,16 +12,15 @@ namespace Pidget.AspNet.Setup
             this IServiceCollection services,
             IConfiguration configuration,
             Action<CallbackSetup> callbackSetup = null)
-            => AddPidgetMiddleware(services, configuration.Bind)
-                .Configure<SentryOptions>(opts =>
-                {
-                    if (callbackSetup == null)
-                    {
-                        return;
-                    }
+            => AddPidgetMiddleware(services, opts =>
+            {
+                configuration.Bind(opts);
 
+                if (callbackSetup != null)
+                {
                     callbackSetup(new CallbackSetup(opts));
-                });
+                }
+            });
 
         public static IServiceCollection AddPidgetMiddleware(
             this IServiceCollection services,

--- a/src/Pidget.AspNet/Setup/SetupExtensions.cs
+++ b/src/Pidget.AspNet/Setup/SetupExtensions.cs
@@ -11,10 +11,17 @@ namespace Pidget.AspNet.Setup
         public static IServiceCollection AddPidgetMiddleware(
             this IServiceCollection services,
             IConfiguration configuration,
-            Action<CallbackSetup> setupCallbacks = null)
+            Action<CallbackSetup> callbackSetup = null)
             => AddPidgetMiddleware(services, configuration.Bind)
-                .Configure<SentryOptions>(opts
-                    => setupCallbacks(new CallbackSetup(opts)));
+                .Configure<SentryOptions>(opts =>
+                {
+                    if (callbackSetup == null)
+                    {
+                        return;
+                    }
+
+                    callbackSetup(new CallbackSetup(opts));
+                });
 
         public static IServiceCollection AddPidgetMiddleware(
             this IServiceCollection services,

--- a/src/Pidget.AspNet/UserDataProvider.cs
+++ b/src/Pidget.AspNet/UserDataProvider.cs
@@ -12,27 +12,24 @@ namespace Pidget.AspNet
 
         public UserData GetUserData(HttpContext http)
         {
-            AssertContextNotNull(http);
+            AssertHttpContextNotNull(http);
 
-            var user = http.User == null
-                ? new UserData()
-                : new UserData
+            return http.User != null
+                ? new UserData
                 {
                     Id = GetId(http.User),
                     UserName = GetUserName(http.User),
                     Email = GetEmail(http.User),
-                };
-
-            user.IpAddress = GetIpAddress(http);
-
-            return user;
+                    IpAddress = GetIpAddress(http)
+                }
+                : null;
         }
 
-        private void AssertContextNotNull(HttpContext context)
+        private void AssertHttpContextNotNull(HttpContext http)
         {
-            if (context == null)
+            if (http == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(http));
             }
         }
 

--- a/src/Pidget.AspNet/UserDataProvider.cs
+++ b/src/Pidget.AspNet/UserDataProvider.cs
@@ -12,8 +12,6 @@ namespace Pidget.AspNet
 
         public UserData GetUserData(HttpContext http)
         {
-            AssertHttpContextNotNull(http);
-
             return http.User != null
                 ? new UserData
                 {
@@ -23,14 +21,6 @@ namespace Pidget.AspNet
                     IpAddress = GetIpAddress(http)
                 }
                 : null;
-        }
-
-        private void AssertHttpContextNotNull(HttpContext http)
-        {
-            if (http == null)
-            {
-                throw new ArgumentNullException(nameof(http));
-            }
         }
 
         public string GetUserName(ClaimsPrincipal user)

--- a/src/Pidget.AspNet/UserDataProvider.cs
+++ b/src/Pidget.AspNet/UserDataProvider.cs
@@ -1,18 +1,13 @@
 using Microsoft.AspNetCore.Http;
 using Pidget.Client.DataModels;
-using System;
 using System.Security.Claims;
 
 namespace Pidget.AspNet
 {
-    public class UserDataProvider
+    public static class UserDataProvider
     {
-        public static UserDataProvider Default { get; }
-             = new UserDataProvider();
-
-        public UserData GetUserData(HttpContext http)
-        {
-            return http.User != null
+        public static UserData GetUserData(HttpContext http)
+            => http.User != null
                 ? new UserData
                 {
                     Id = GetId(http.User),
@@ -21,23 +16,22 @@ namespace Pidget.AspNet
                     IpAddress = GetIpAddress(http)
                 }
                 : null;
-        }
 
-        public string GetUserName(ClaimsPrincipal user)
+        public static  string GetUserName(ClaimsPrincipal user)
             => user.Identity?.Name
             ?? user.FindFirst(ClaimTypes.Name)?.Value;
 
-        public string GetEmail(ClaimsPrincipal user)
+        public static string GetEmail(ClaimsPrincipal user)
             => user.FindFirst(ClaimTypes.Email)?.Value;
 
-        public string GetId(ClaimsPrincipal user)
+        public static string GetId(ClaimsPrincipal user)
             => user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 
-        public string GetIpAddress(HttpContext http)
+        public static string GetIpAddress(HttpContext http)
             => GetXForwardedFor(http.Request)
             ?? http.Connection?.RemoteIpAddress?.ToString();
 
-        private string GetXForwardedFor(HttpRequest req)
+        private static string GetXForwardedFor(HttpRequest req)
         {
             req.Headers?.TryGetValue("X-Forwarded-For",
                 out var forwardedFor);

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -6,9 +6,9 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 using static System.Threading.CancellationToken;
-using System.Collections.Generic;
 
 namespace Pidget.Client.Http
 {

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 using static System.Threading.CancellationToken;
+using System.Collections.Generic;
 
 namespace Pidget.Client.Http
 {
@@ -86,17 +87,17 @@ namespace Pidget.Client.Http
             var message = new HttpRequestMessage(HttpMethod.Post,
                 Dsn.GetCaptureUrl());
 
-            AddSentryAuthHeader(message);
+            message.Headers.Add(SentryAuthHeader.Name,
+                GetSentryAuthHeader());
 
             message.Content = GetContent(stream);
 
             return message;
         }
 
-        private void AddSentryAuthHeader(HttpRequestMessage message)
-            => message.Headers.Add(SentryAuthHeader.Name,
-                SentryAuthHeader.GetValues(
-                    SentryAuth.Issue(this, DateTimeOffset.Now)));
+        private IEnumerable<string> GetSentryAuthHeader()
+            => SentryAuthHeader.GetValues(
+                SentryAuth.Issue(this, DateTimeOffset.Now));
 
         private static StreamContent GetContent(Stream stream)
         {

--- a/src/Pidget.Client/SentryClient.cs
+++ b/src/Pidget.Client/SentryClient.cs
@@ -8,7 +8,8 @@ namespace Pidget.Client
     {
         public const string Name = "pidget";
 
-        public static string Version => VersionNumber.Get();
+        public static string Version { get; }
+            = VersionNumber.Get();
 
         public Dsn Dsn { get; }
 

--- a/src/Pidget.Client/Serialization/JsonStreamSerializer.cs
+++ b/src/Pidget.Client/Serialization/JsonStreamSerializer.cs
@@ -22,7 +22,7 @@ namespace Pidget.Client.Serialization
 
         public Stream Serialize(object item)
         {
-            var stream = new MemoryStream(256);
+            var stream = new MemoryStream(BufferSize);
 
             using (var writer = CreateWriter(stream))
             {

--- a/src/Pidget.Client/VersionNumber.cs
+++ b/src/Pidget.Client/VersionNumber.cs
@@ -5,12 +5,7 @@ namespace Pidget.Client
 {
     internal static class VersionNumber
     {
-        private static string _versionNumber;
-
         public static string Get()
-            => (_versionNumber ?? (_versionNumber = GetProductVersion()));
-
-        private static string GetProductVersion()
             => FileVersionInfo.GetVersionInfo(
                 Assembly.GetExecutingAssembly().Location).ProductVersion;
     }

--- a/test/Pidget.AspNet.Test/Pidget.AspNet.Test.csproj
+++ b/test/Pidget.AspNet.Test/Pidget.AspNet.Test.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Moq" Version="4.7.142" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Pidget.AspNet.Test/SentryMiddlewareTests.cs
+++ b/test/Pidget.AspNet.Test/SentryMiddlewareTests.cs
@@ -21,7 +21,7 @@ namespace Pidget.AspNet.Test
 
         public RequestDelegate Next_Noop = _ => Task.CompletedTask;
 
-        public SentryOptions ExceptionReportingOptions
+        public SentryOptions SentryOptions
             = new SentryOptions
             {
                 Dsn = "https://PUBLIC:SECRET@sentry.io/PROJECT_ID"
@@ -31,7 +31,7 @@ namespace Pidget.AspNet.Test
         public async Task SuccessfulInvoke_DoesNotSend()
         {
             var clientMock = new Mock<SentryClient>(
-                Dsn.Create(ExceptionReportingOptions.Dsn));
+                Dsn.Create(SentryOptions.Dsn));
 
             var middleware = CreateMiddleware(Next_Noop, clientMock.Object);
 
@@ -54,7 +54,7 @@ namespace Pidget.AspNet.Test
                 .Returns(reqMock.Object);
 
             var clientMock = new Mock<SentryClient>(
-                Dsn.Create(ExceptionReportingOptions.Dsn));
+                Dsn.Create(SentryOptions.Dsn));
 
             clientMock.Setup(c => c.SendEventAsync(It.IsAny<SentryEventData>()))
                 .ReturnsAsync(new SentryResponse { EventId = eventId })
@@ -96,7 +96,7 @@ namespace Pidget.AspNet.Test
                 .Returns(reqMock.Object);
 
             var clientMock = new Mock<SentryClient>(
-                Dsn.Create(ExceptionReportingOptions.Dsn));
+                Dsn.Create(SentryOptions.Dsn));
 
             clientMock.Setup(c => c.SendEventAsync(It.Is<SentryEventData>(r
                 => r.Request.Url == url.Split('?', StringSplitOptions.None)[0]
@@ -153,7 +153,7 @@ namespace Pidget.AspNet.Test
                 .Returns(reqMock.Object);
 
             var clientMock = new Mock<SentryClient>(
-                Dsn.Create(ExceptionReportingOptions.Dsn));
+                Dsn.Create(SentryOptions.Dsn));
 
             clientMock.Setup(c => c.SendEventAsync(It.Is<SentryEventData>(r
                  => r.User.Id == userId
@@ -185,7 +185,7 @@ namespace Pidget.AspNet.Test
                 .Returns(reqMock.Object);
 
             var clientMock = new Mock<SentryClient>(
-                Dsn.Create(ExceptionReportingOptions.Dsn));
+                Dsn.Create(SentryOptions.Dsn));
 
             const int retryAfterMs = 500;
 
@@ -234,7 +234,10 @@ namespace Pidget.AspNet.Test
         public SentryMiddleware CreateMiddleware(RequestDelegate next,
             SentryClient client)
             => new SentryMiddleware(next,
-                Options.Create(ExceptionReportingOptions),
+                new ConfigureOptions<SentryOptions>(opts =>
+                {
+                    opts.Dsn = SentryOptions.Dsn;
+                }),
                 client,
                 new RateLimit());
     }

--- a/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
+++ b/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
@@ -89,5 +89,41 @@ namespace Pidget.AspNet.Setup
 
             appMock.Verify();
         }
+
+        [Theory, InlineData("https://pub:secreet@sentry.io/1")]
+        public void ActivateClient_Setup_HasCorrectDsn(string dsn)
+        {
+            var services = new ServiceCollection();
+
+            services.AddPidgetMiddleware(sentry =>
+            {
+                sentry.Dsn = dsn;
+            });
+
+            var provider = services.BuildServiceProvider();
+
+            var client = (SentryClient)provider.GetService(typeof(SentryClient));
+
+            Assert.NotNull(client);
+            Assert.Equal(dsn, client.Dsn.ToString());
+        }
+
+        [Theory, InlineData("https://pub:secreet@sentry.io/1")]
+        public void ActivateClient_Config_HasCorrectDsn(string dsn)
+        {
+            var services = new ServiceCollection();
+            var configMock = new Mock<IConfigurationSection>();
+
+            configMock.SetupGet(s => s["Dsn"]).Returns(dsn);
+
+            services.AddPidgetMiddleware(configMock.Object);
+
+            var provider = services.BuildServiceProvider();
+
+            var client = (SentryClient)provider.GetService(typeof(SentryClient));
+
+            Assert.NotNull(client);
+            Assert.Equal(dsn, client.Dsn.ToString());
+        }
     }
 }

--- a/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
+++ b/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
 using Pidget.Client;
-using Pidget.Client.Http;
 using Xunit;
 
 namespace Pidget.AspNet.Setup
@@ -14,12 +13,14 @@ namespace Pidget.AspNet.Setup
     public class SetupExtensionsTests
     {
         [Fact]
-        public void AddPidgetMiddleware_AddsClient()
+        public void AddPidgetMiddleware_AddsScopedClient()
         {
             var servicesMock = new Mock<IServiceCollection>();
 
             servicesMock.Setup(m => m
-                .Add(It.Is<ServiceDescriptor>(s => typeof(SentryClient) == s.ServiceType)))
+                .Add(It.Is<ServiceDescriptor>(s
+                    => s.ServiceType == typeof(SentryClient)
+                    && s.Lifetime == ServiceLifetime.Scoped)))
                 .Verifiable();
 
             servicesMock.Object.AddPidgetMiddleware(_ => {});
@@ -34,7 +35,7 @@ namespace Pidget.AspNet.Setup
 
             servicesMock.Setup(m => m
                 .Add(It.Is<ServiceDescriptor>(s
-                    => typeof(RateLimit) == s.ServiceType
+                    => s.ServiceType == typeof(RateLimit)
                     && s.Lifetime == ServiceLifetime.Singleton)))
                 .Verifiable();
 
@@ -44,13 +45,14 @@ namespace Pidget.AspNet.Setup
         }
 
         [Fact]
-        public void AddPidgetMiddleware_Setup_AddsOptions()
+        public void AddPidgetMiddleware_Setup_AddsSingletonOptions()
         {
             var servicesMock = new Mock<IServiceCollection>();
 
             servicesMock.Setup(m => m
-                .Add(It.Is<ServiceDescriptor>(
-                    s => typeof(IConfigureOptions<SentryOptions>) == s.ServiceType)))
+                .Add(It.Is<ServiceDescriptor>(s
+                    => s.ServiceType == typeof(IConfigureOptions<SentryOptions>)
+                    && s.Lifetime == ServiceLifetime.Singleton)))
                 .Verifiable();
 
             servicesMock.Object.AddPidgetMiddleware(_ => {});
@@ -59,13 +61,14 @@ namespace Pidget.AspNet.Setup
         }
 
         [Fact]
-        public void AddPidgetMiddleware_Configuration_AddsOptions()
+        public void AddPidgetMiddleware_Configuration_AddsSingletonOptions()
         {
             var servicesMock = new Mock<IServiceCollection>();
 
             servicesMock.Setup(m => m
-                .Add(It.Is<ServiceDescriptor>(
-                    s => typeof(IConfigureOptions<SentryOptions>) == s.ServiceType)))
+                .Add(It.Is<ServiceDescriptor>(s
+                    => s.ServiceType == typeof(IConfigureOptions<SentryOptions>)
+                    && s.Lifetime == ServiceLifetime.Singleton)))
                 .Verifiable();
 
             servicesMock.Object.AddPidgetMiddleware(

--- a/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
+++ b/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
@@ -91,7 +91,7 @@ namespace Pidget.AspNet.Setup
         }
 
         [Theory, InlineData("https://pub:secreet@sentry.io/1")]
-        public void ActivateClient_Setup_HasCorrectDsn(string dsn)
+        public void ActivateClient_HasCorrectDsn(string dsn)
         {
             var services = new ServiceCollection();
 
@@ -99,24 +99,6 @@ namespace Pidget.AspNet.Setup
             {
                 sentry.Dsn = dsn;
             });
-
-            var provider = services.BuildServiceProvider();
-
-            var client = (SentryClient)provider.GetService(typeof(SentryClient));
-
-            Assert.NotNull(client);
-            Assert.Equal(dsn, client.Dsn.ToString());
-        }
-
-        [Theory, InlineData("https://pub:secreet@sentry.io/1")]
-        public void ActivateClient_Config_HasCorrectDsn(string dsn)
-        {
-            var services = new ServiceCollection();
-            var configMock = new Mock<IConfigurationSection>();
-
-            configMock.SetupGet(s => s["Dsn"]).Returns(dsn);
-
-            services.AddPidgetMiddleware(configMock.Object);
 
             var provider = services.BuildServiceProvider();
 

--- a/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
+++ b/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
@@ -29,7 +29,7 @@ namespace Pidget.AspNet.Setup
         }
 
         [Fact]
-        public void AddPidgetMiddleware_AddsRateLimit()
+        public void AddPidgetMiddleware_AddsSingletonRateLimit()
         {
             var servicesMock = new Mock<IServiceCollection>();
 

--- a/test/Pidget.AspNet.Test/UserDataProviderTests.cs
+++ b/test/Pidget.AspNet.Test/UserDataProviderTests.cs
@@ -11,11 +11,6 @@ namespace Pidget.AspNet
 {
     public class UserDataProviderTests
     {
-        [Fact]
-        public void GetUserData_ThrowsArgumentNull_ForNullContext()
-            => Assert.Throws<ArgumentNullException>(()
-                => UserDataProvider.Default.GetUserData(null));
-
         [Theory, InlineData("1")]
         public void GetId_UsesNameIdentifierClaim(string id)
         {

--- a/test/Pidget.AspNet.Test/UserDataProviderTests.cs
+++ b/test/Pidget.AspNet.Test/UserDataProviderTests.cs
@@ -16,7 +16,7 @@ namespace Pidget.AspNet
         {
             var user = MakeUser(Tuple.Create(ClaimTypes.NameIdentifier, id));
 
-            Assert.Equal(id, UserDataProvider.Default.GetId(user));
+            Assert.Equal(id, UserDataProvider.GetId(user));
         }
 
         [Theory, InlineData("foo@bar")]
@@ -24,7 +24,7 @@ namespace Pidget.AspNet
         {
             var user = MakeUser(Tuple.Create(ClaimTypes.Email, email));
 
-            Assert.Equal(email, UserDataProvider.Default.GetEmail(user));
+            Assert.Equal(email, UserDataProvider.GetEmail(user));
         }
 
         [Theory, InlineData("user")]
@@ -38,7 +38,7 @@ namespace Pidget.AspNet
 
             var user = new ClaimsPrincipal(identityMock.Object);
 
-            Assert.Equal(userName, UserDataProvider.Default.GetUserName(user));
+            Assert.Equal(userName, UserDataProvider.GetUserName(user));
 
             identityMock.Verify();
         }
@@ -48,7 +48,7 @@ namespace Pidget.AspNet
         {
             var user = MakeUser(Tuple.Create(ClaimTypes.Name, userName));
 
-            Assert.Equal(userName, UserDataProvider.Default.GetUserName(user));
+            Assert.Equal(userName, UserDataProvider.GetUserName(user));
         }
 
         [Theory, InlineData("user")]
@@ -67,7 +67,7 @@ namespace Pidget.AspNet
 
             var user = new ClaimsPrincipal(identityMock.Object);
 
-            Assert.Equal(userName, UserDataProvider.Default.GetUserName(user));
+            Assert.Equal(userName, UserDataProvider.GetUserName(user));
 
             identityMock.Verify();
         }
@@ -95,7 +95,7 @@ namespace Pidget.AspNet
                 .Returns(reqMock.Object);
 
             Assert.Equal(ipAddress,
-                UserDataProvider.Default.GetIpAddress(httpMock.Object));
+                UserDataProvider.GetIpAddress(httpMock.Object));
 
             connMock.Verify();
         }
@@ -126,7 +126,7 @@ namespace Pidget.AspNet
                 .Returns(reqMock.Object);
 
             Assert.Equal(xForwardedFor,
-                UserDataProvider.Default.GetIpAddress(httpMock.Object));
+                UserDataProvider.GetIpAddress(httpMock.Object));
         }
 
         [Theory]
@@ -162,7 +162,7 @@ namespace Pidget.AspNet
             httpMock.SetupGet(c => c.Request)
                 .Returns(Mock.Of<HttpRequest>());
 
-            var data = UserDataProvider.Default.GetUserData(httpMock.Object);
+            var data = UserDataProvider.GetUserData(httpMock.Object);
 
             Assert.Equal(id, data.Id);
             Assert.Equal(userName, data.UserName);
@@ -187,7 +187,7 @@ namespace Pidget.AspNet
             httpMock.SetupGet(r => r.Request)
                 .Returns(Mock.Of<HttpRequest>());
 
-            var data = UserDataProvider.Default.GetUserData(httpMock.Object);
+            var data = UserDataProvider.GetUserData(httpMock.Object);
 
             Assert.Null(data.Id);
             Assert.Null(data.UserName);


### PR DESCRIPTION
Ended up using `IOptions` instead of `IConfigureOptions` in the middleware; which made activating the middleware impossible. Really sloppy. 

Ended up improving some things though, and getting better test coverage.