### PR TITLE
Resolve dependency resolving issues

### DIFF
--- a/src/Pidget.AspNet/Setup/SetupExtensions.cs
+++ b/src/Pidget.AspNet/Setup/SetupExtensions.cs
@@ -26,7 +26,7 @@ namespace Pidget.AspNet.Setup
             this IServiceCollection services,
             Action<SentryOptions> setup)
             => services.Configure<SentryOptions>(setup)
-                .AddScoped<SentryClient>(ClientFactory.CreateClient)
+                .AddSingleton<SentryClient>(ClientFactory.CreateClient)
                 .AddSingleton<RateLimit>();
 
         public static IApplicationBuilder UsePidgetMiddleware(

--- a/src/Pidget.Client/ErrorLevel.cs
+++ b/src/Pidget.Client/ErrorLevel.cs
@@ -1,5 +1,9 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
 namespace Pidget.Client
 {
+    [JsonConverter(typeof(StringEnumConverter), true)]
     public enum ErrorLevel : byte
     {
         Error,

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -23,7 +23,7 @@ namespace Pidget.Client.Http
         private static readonly JsonStreamSerializer _serializer
             = new JsonStreamSerializer(
                 encoding: Sentry.ApiEncoding,
-                jsonSerializer: CreateJsonSerializer());
+                jsonSerializer: JsonSerializer.CreateDefault());
 
         private readonly HttpMessageInvoker _sender;
 
@@ -95,16 +95,6 @@ namespace Pidget.Client.Http
             content.Headers.Add("Content-Type", "application/json");
 
             return content;
-        }
-
-        private static JsonSerializer CreateJsonSerializer()
-        {
-            var settings = new JsonSerializerSettings();
-
-            settings.Converters.Add(
-                new StringEnumConverter(camelCaseText: true));
-
-            return JsonSerializer.Create(settings);
         }
     }
 }

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -12,7 +12,7 @@ using static System.Threading.CancellationToken;
 
 namespace Pidget.Client.Http
 {
-    public class SentryHttpClient : SentryClient, IDisposable
+    public class SentryHttpClient : SentryClient
     {
         public static TimeSpan Timeout { get; }
             = TimeSpan.FromSeconds(3);
@@ -67,8 +67,6 @@ namespace Pidget.Client.Http
                 return await responseProvider.GetResponseAsync(httpResponse);
             }
         }
-
-        public void Dispose() => _sender.Dispose();
 
         public static HttpClient CreateHttpClient()
         {

--- a/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
+++ b/test/Pidget.AspNet.Test/Setup/SetupExtensionsTests.cs
@@ -13,14 +13,14 @@ namespace Pidget.AspNet.Setup
     public class SetupExtensionsTests
     {
         [Fact]
-        public void AddPidgetMiddleware_AddsScopedClient()
+        public void AddPidgetMiddleware_AddsSingletonClient()
         {
             var servicesMock = new Mock<IServiceCollection>();
 
             servicesMock.Setup(m => m
                 .Add(It.Is<ServiceDescriptor>(s
                     => s.ServiceType == typeof(SentryClient)
-                    && s.Lifetime == ServiceLifetime.Scoped)))
+                    && s.Lifetime == ServiceLifetime.Singleton)))
                 .Verifiable();
 
             servicesMock.Object.AddPidgetMiddleware(_ => {});

--- a/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
+++ b/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
@@ -83,19 +83,6 @@ namespace Pidget.Client.Test
         }
 
         [Fact]
-        public void DisposesSender()
-        {
-            var sender = new TestSender(new HttpClientHandler());
-
-            var client = new SentryHttpClient(DsnTests.SentryDsn,
-                sender);
-
-            client.Dispose();
-
-            Assert.True(sender.IsDisposed);
-        }
-
-        [Fact]
         public void CreateDefault()
             => Assert.NotNull(
                 SentryHttpClient.Default(DsnTests.SentryDsn));

--- a/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
+++ b/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
@@ -49,7 +49,7 @@ namespace Pidget.Client.Test
                 senderMock.Object);
 
             senderMock.Setup(m => m.SendAsync(It.IsAny<HttpRequestMessage>(), None))
-                .ReturnsAsync(CreateOkHttpResponse(SentryHttpClient.JsonSerializer))
+                .ReturnsAsync(CreateOkHttpResponse(JsonSerializer.CreateDefault()))
                 .Verifiable();
 
             var response = await client.SendEventAsync(new SentryEventData

--- a/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
+++ b/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
@@ -34,7 +34,7 @@ namespace Pidget.Client.Test
         [Fact]
         public void Sender_HasExpectedUserAgent()
         {
-            var httpClient = SentryHttpClient.CreateHttpClient();
+            var httpClient = SentryHttpClient.CreateDefaultHttpClient();
 
             Assert.Equal(SentryHttpClient.UserAgent,
                 httpClient.DefaultRequestHeaders.UserAgent.ToString());


### PR DESCRIPTION
This solves PR #31 
There are some discrepancies between how scoped services are resolved depending on what `ASPNET_ENVIRONMENT` is set. The `SentryClient`-service in Sentry.AspNet fails to resolve if the environment is set to `Development`, but works with `Production`. 

I decided to work around the problem by injecting the `SentryClient` as a singleton. This felt a bit risky at first, seeing it would create a shared underlaying `HttpClient` as well, but apparently this is perfectly safe, and [considered "best practice" by some](https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/).

While reading up on the `HttpClient`, I also noticed that `HttpResponseMessage` is disposable, and that *it should* be disposed, so that has also been taken care of.

I also removed the requirement for a custom JSON serializer in the `SentryHttpClient`, the default serializer now suffices.