### PR TITLE
Codecov integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ examples/Pidget.AspNetExample/appsettings.json
 coverage-html/
 coverage.json
 coverage-hits.txt
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ install:
 - dotnet restore
 
 script:
-- sh test.sh
 - sh codecov.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ install:
 - dotnet restore
 
 script:
-- dotnet build -c Debug
-- dotnet test --no-build test/Pidget.Client.Test/Pidget.Client.Test.csproj
-- dotnet test --no-build test/Pidget.AspNet.Test/Pidget.AspNet.Test.csproj
+- sh test.sh
+- sh codecov.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,10 @@ install:
 - dotnet restore
 
 script:
+# Only run codecov:
+# - he build
+# - he test
+# - he report
+# but most importantly
+# - he protec
 - sh codecov.sh

--- a/codecov.sh
+++ b/codecov.sh
@@ -1,5 +1,3 @@
-dotnet restore
-
 cd tools/code-coverage
 
 dotnet restore
@@ -18,7 +16,7 @@ cd tools/code-coverage
 
 dotnet minicover uninstrument --workdir ../../
 
-dotnet minicover xmlreport --workdir ../../
+dotnet minicover opencoverreport --workdir ../../ --output coverage.xml
 
 cd ../..
 

--- a/codecov.sh
+++ b/codecov.sh
@@ -22,4 +22,4 @@ dotnet minicover opencoverreport --workdir ../../ --output coverage.xml
 
 cd ../..
 
-curl -s https://codecov.io/bash | bash -s - -t ac12fe3c-28ae-4b9c-b65c-4d3879e7e942 -f coverage.xml
+curl -s https://codecov.io/bash | bash -s - -t ac12fe3c-28ae-4b9c-b65c-4d3879e7e942

--- a/codecov.sh
+++ b/codecov.sh
@@ -2,7 +2,7 @@ dotnet restore
 
 cd tools/code-coverage
 
-dotnet restore --no-cache --force
+dotnet restore
 
 # Instrument assemblies inside 'test' folder to detect hits for source files inside 'src' folder
 dotnet minicover instrument --workdir ../../ --assemblies test/**/bin/**/*.dll --sources src/**/*.cs
@@ -18,7 +18,7 @@ cd tools/code-coverage
 
 dotnet minicover uninstrument --workdir ../../
 
-dotnet minicover opencoverreport --workdir ../../ --output coverage.xml
+dotnet minicover xmlreport --workdir ../../
 
 cd ../..
 

--- a/codecov.sh
+++ b/codecov.sh
@@ -22,4 +22,4 @@ dotnet minicover opencoverreport --workdir ../../ --output coverage.xml
 
 cd ../..
 
-curl -s https://codecov.io/bash | bash -s - -t ac12fe3c-28ae-4b9c-b65c-4d3879e7e942
+curl -s https://codecov.io/bash | bash -s - -t ac12fe3c-28ae-4b9c-b65c-4d3879e7e942 -f coverage.xml

--- a/codecov.sh
+++ b/codecov.sh
@@ -2,6 +2,8 @@ dotnet restore
 
 cd tools/code-coverage
 
+dotnet restore --no-cache --force
+
 # Instrument assemblies inside 'test' folder to detect hits for source files inside 'src' folder
 dotnet minicover instrument --workdir ../../ --assemblies test/**/bin/**/*.dll --sources src/**/*.cs
 

--- a/codecov.sh
+++ b/codecov.sh
@@ -1,0 +1,23 @@
+dotnet restore
+
+cd tools/code-coverage
+
+# Instrument assemblies inside 'test' folder to detect hits for source files inside 'src' folder
+dotnet minicover instrument --workdir ../../ --assemblies test/**/bin/**/*.dll --sources src/**/*.cs
+
+# Reset hits count in case minicover was run for this project
+dotnet minicover reset
+
+cd ../../
+
+for project in test/**/*.csproj; do dotnet test $project; done
+
+cd tools/code-coverage
+
+dotnet minicover uninstrument --workdir ../../
+
+dotnet minicover opencoverreport --workdir ../../ --output coverage.xml
+
+cd ../..
+
+curl -s https://codecov.io/bash | bash -s - -t ac12fe3c-28ae-4b9c-b65c-4d3879e7e942

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,5 +1,4 @@
 dotnet restore
-dotnet build
 
 cd tools/code-coverage
 
@@ -11,7 +10,7 @@ dotnet minicover reset
 
 cd ../../
 
-for project in test/**/*.csproj; do dotnet test --no-build $project; done
+for project in test/**/*.csproj; do dotnet test $project; done
 
 cd tools/code-coverage
 
@@ -25,4 +24,4 @@ dotnet minicover htmlreport --workdir ../../ --threshold 90
 # This command returns failure if the coverage is lower than the threshold
 dotnet minicover report --workdir ../../ --threshold 90
 
-cd ..
+cd ../..

--- a/coverage.sh
+++ b/coverage.sh
@@ -14,8 +14,6 @@ for project in test/**/*.csproj; do dotnet test $project; done
 
 cd tools/code-coverage
 
-dotnet restore --force --no-cache
-
 # Uninstrument assemblies, it's important if you're going to publish or deploy build outputs
 dotnet minicover uninstrument --workdir ../../
 

--- a/coverage.sh
+++ b/coverage.sh
@@ -14,6 +14,8 @@ for project in test/**/*.csproj; do dotnet test $project; done
 
 cd tools/code-coverage
 
+dotnet restore --force --no-cache
+
 # Uninstrument assemblies, it's important if you're going to publish or deploy build outputs
 dotnet minicover uninstrument --workdir ../../
 


### PR DESCRIPTION
I've integrated the project with [codecov](https://codecov.io/). 
The project can be found at: https://codecov.io/gh/mausworks/pidget
I've also changed so the only script-step in travis is the codecov.sh, it builds the project, runs all tests and reports to codecov, I'd say this is pretty extensive.

There is now also this cool badge:

[![Codecov](https://img.shields.io/codecov/c/github/mausworks/pidget.svg)](https://codecov.io/gh/mausworks/pidget)