### PR TITLE
Test coverage + tweaks/fixes

### DIFF
--- a/src/Pidget.Client/DataModels/DeviceData.cs
+++ b/src/Pidget.Client/DataModels/DeviceData.cs
@@ -38,7 +38,7 @@ namespace Pidget.Client.DataModels
 
         public double? BatteryLevel
         {
-            get => this["arch"] as double?;
+            get => this["battery_level"] as double?;
             set => this["battery_level"] = value;
         }
 

--- a/src/Pidget.Client/DataModels/FrameData.cs
+++ b/src/Pidget.Client/DataModels/FrameData.cs
@@ -7,9 +7,6 @@ namespace Pidget.Client.DataModels
 {
     public class FrameData
     {
-        [JsonProperty("abs_path")]
-        public string AbsolutePath { get; set; }
-
         [JsonProperty("lineno")]
         public int LineNumber { get; set; }
 

--- a/src/Pidget.Client/DataModels/FrameData.cs
+++ b/src/Pidget.Client/DataModels/FrameData.cs
@@ -7,8 +7,6 @@ namespace Pidget.Client.DataModels
 {
     public class FrameData
     {
-        private const string UnknownMemberReplacement = "(unknown)";
-
         [JsonProperty("abs_path")]
         public string AbsolutePath { get; set; }
 
@@ -45,20 +43,15 @@ namespace Pidget.Client.DataModels
                 LineNumber = GetLineNumber(stackFrame),
                 ColumnNumber = stackFrame.GetFileColumnNumber(),
                 InApp = IsInApp(method),
-                Module = GetModule(method),
-                Function = GetMethodName(method),
-                ContextLine = GetMethodSource(method)
+                Module = method.DeclaringType.FullName,
+                Function = method.Name,
+                ContextLine = method.ToString()
             };
         }
 
         private static bool IsInApp(MethodBase method)
         {
-            if (method == null)
-            {
-                return true;
-            }
-
-            var module = GetModule(method);
+            var module = method.DeclaringType.FullName;
 
             return !module.StartsWith("System.", StringComparison.Ordinal)
                 && !module.StartsWith("Microsoft.", StringComparison.Ordinal);
@@ -71,17 +64,5 @@ namespace Pidget.Client.DataModels
             return lineNumber != 0 ? lineNumber
                 : stackFrame.GetILOffset();
         }
-
-        private static string GetMethodSource(MethodBase method)
-            => method?.ToString()
-            ?? UnknownMemberReplacement;
-
-        private static string GetMethodName(MethodBase method)
-            => method?.Name
-            ?? UnknownMemberReplacement;
-
-        private static string GetModule(MethodBase method)
-            => method?.DeclaringType.FullName
-            ?? UnknownMemberReplacement;
     }
 }

--- a/test/Pidget.AspNet.Test/SentryMiddlewareTests.cs
+++ b/test/Pidget.AspNet.Test/SentryMiddlewareTests.cs
@@ -17,7 +17,7 @@ namespace Pidget.AspNet.Test
     public class SentryMiddlewareTests
     {
         public RequestDelegate Next_Throw = _ =>
-            throw new InvalidOperationException("Hey, look at me!");
+            throw new Exception("Hey, look at me!");
 
         public RequestDelegate Next_Noop = _ => Task.CompletedTask;
 

--- a/test/Pidget.AspNet.Test/SentryOptionsTests.cs
+++ b/test/Pidget.AspNet.Test/SentryOptionsTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Pidget.AspNet
+{
+    public class SentryOptionsTests
+    {
+        [Fact]
+        public void CallbackSetup_SetsOptions()
+        {
+            var opts = new SentryOptions();
+            var initialBeforeSend = opts.BeforeSendCallback;
+            var initialAfterSend = opts.AfterSendCallback;
+
+            opts.Callbacks.BeforeSend((b, h) => Task.FromResult(true))
+                .AfterSend((r, h) => Task.CompletedTask);
+
+            Assert.NotEqual(initialBeforeSend, opts.BeforeSendCallback);
+            Assert.NotEqual(initialAfterSend, opts.AfterSendCallback);
+        }
+    }
+}

--- a/test/Pidget.AspNet.Test/Setup/CallbackSetupTests.cs
+++ b/test/Pidget.AspNet.Test/Setup/CallbackSetupTests.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using Pidget.AspNet.Setup;
+using Xunit;
+
+namespace Pidget.AspNet.Test.Setup
+{
+    public class CallbackSetupTests
+    {
+
+        [Fact]
+        public void SetsBeforeSendCallback()
+        {
+            var options = new SentryOptions();
+            var initialCallback = options.BeforeSendCallback;
+
+            var setup = new CallbackSetup(options);
+
+            setup.BeforeSend((b, h) => Task.FromResult(true));
+
+            Assert.NotEqual(initialCallback, options.BeforeSendCallback);
+        }
+
+        [Fact]
+        public void SetsAfterSendCallback()
+        {
+            var options = new SentryOptions();
+            var initialCallback = options.AfterSendCallback;
+
+            var setup = new CallbackSetup(options);
+
+            setup.AfterSend((b, h) => Task.CompletedTask);
+
+            Assert.NotEqual(initialCallback, options.AfterSendCallback);
+        }
+    }
+}

--- a/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
+++ b/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
@@ -40,24 +40,29 @@ namespace Pidget.Client.Test.DataModels
         [Fact]
         public void ImplementsDictionary()
         {
-            var data = new ArbitraryData()
+            var data = new ArbitraryData
             {
                 { "foo", "bar" }
             };
 
+            Assert.False(data.IsReadOnly);
+
             data.Add("bar", "baz");
             data.Add(new KeyValuePair<string, object>("baz", "foo"));
 
-            Assert.False(data.IsReadOnly);
             Assert.True(data.Count == 3);
-            Assert.True(data.ContainsKey("bar"));
-            Assert.True(data.Contains(
-                new KeyValuePair<string, object>("foo", "bar")));
 
             var copy = new KeyValuePair<string, object>[data.Count];
             data.CopyTo(copy, 0);
 
             Assert.Equal(data.ToArray(), copy);
+
+            data.Remove("foo");
+            Assert.False(data.ContainsKey("foo"));
+
+            data.Remove(new KeyValuePair<string, object>("bar", "baz"));
+            Assert.False(data.Contains(
+                new KeyValuePair<string, object>("bar", "baz")));
 
             data.Clear();
             Assert.Equal(0, data.Count);

--- a/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
+++ b/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
@@ -56,7 +56,6 @@ namespace Pidget.Client.Test.DataModels
             Assert.Equal(data["rooted"], data.Rooted);
         }
 
-
         [Fact]
         public void RuntimeData_SetsCorrectKeys()
         {

--- a/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
+++ b/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
@@ -38,6 +38,62 @@ namespace Pidget.Client.Test.DataModels
         }
 
         [Fact]
+        public void OperatingSystemData_SetsBackingFields()
+        {
+            var data = new OperatingSystemData
+            {
+                Name = "foo",
+                Version = "1",
+                Build = "1",
+                KernelVersion = "1",
+                Rooted = true
+            };
+
+            Assert.Equal(data["name"], data.Name);
+            Assert.Equal(data["version"], data.Version);
+            Assert.Equal(data["build"], data.Build);
+            Assert.Equal(data["kernel_version"], data.KernelVersion);
+            Assert.Equal(data["rooted"], data.Rooted);
+        }
+
+
+        [Fact]
+        public void RuntimeData_SetsBackingFields()
+        {
+            var data = new RuntimeData
+            {
+                Name = "foo",
+                Version = "1",
+            };
+
+            Assert.Equal(data["name"], data.Name);
+            Assert.Equal(data["version"], data.Version);
+        }
+
+        [Fact]
+        public void DeviceData_SetsBackingFields()
+        {
+            var data = new DeviceData
+            {
+                Name = "1",
+                Family = "2",
+                Model = "3",
+                ModelId = "4",
+                Architecture = "5",
+                BatteryLevel = 6,
+                Orientation = "7"
+            };
+
+            Assert.Equal(data["name"], data.Name);
+            Assert.Equal(data["family"], data.Family);
+            Assert.Equal(data["model"], data.Model);
+            Assert.Equal(data["model_id"], data.ModelId);
+            Assert.Equal(data["arch"], data.Architecture);
+            Assert.Equal(data["battery_level"], data.BatteryLevel);
+            Assert.Equal(data["orientation"], data.Orientation);
+        }
+
+        [Fact]
         public void ImplementsDictionary()
         {
             var data = new ArbitraryData

--- a/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
+++ b/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
@@ -38,14 +38,14 @@ namespace Pidget.Client.Test.DataModels
         }
 
         [Fact]
-        public void OperatingSystemData_SetsBackingFields()
+        public void OperatingSystemData_SetsCorrectKeys()
         {
             var data = new OperatingSystemData
             {
                 Name = "foo",
                 Version = "1",
-                Build = "1",
-                KernelVersion = "1",
+                Build = "2",
+                KernelVersion = "3",
                 Rooted = true
             };
 
@@ -58,7 +58,7 @@ namespace Pidget.Client.Test.DataModels
 
 
         [Fact]
-        public void RuntimeData_SetsBackingFields()
+        public void RuntimeData_SetsCorrectKeys()
         {
             var data = new RuntimeData
             {
@@ -71,17 +71,17 @@ namespace Pidget.Client.Test.DataModels
         }
 
         [Fact]
-        public void DeviceData_SetsBackingFields()
+        public void DeviceData_SetsCorrectKeys()
         {
             var data = new DeviceData
             {
-                Name = "1",
-                Family = "2",
-                Model = "3",
-                ModelId = "4",
-                Architecture = "5",
-                BatteryLevel = 6,
-                Orientation = "7"
+                Name = "foo",
+                Family = "bar",
+                Model = "baz",
+                ModelId = "1",
+                Architecture = "1",
+                BatteryLevel = 3,
+                Orientation = "south"
             };
 
             Assert.Equal(data["name"], data.Name);

--- a/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
+++ b/test/Pidget.Client.Test/DataModels/ArbitraryDataTests.cs
@@ -36,5 +36,31 @@ namespace Pidget.Client.Test.DataModels
             Assert.True(data.TryGetValue(key, out object outValue));
             Assert.Equal(value, outValue);
         }
+
+        [Fact]
+        public void ImplementsDictionary()
+        {
+            var data = new ArbitraryData()
+            {
+                { "foo", "bar" }
+            };
+
+            data.Add("bar", "baz");
+            data.Add(new KeyValuePair<string, object>("baz", "foo"));
+
+            Assert.False(data.IsReadOnly);
+            Assert.True(data.Count == 3);
+            Assert.True(data.ContainsKey("bar"));
+            Assert.True(data.Contains(
+                new KeyValuePair<string, object>("foo", "bar")));
+
+            var copy = new KeyValuePair<string, object>[data.Count];
+            data.CopyTo(copy, 0);
+
+            Assert.Equal(data.ToArray(), copy);
+
+            data.Clear();
+            Assert.Equal(0, data.Count);
+        }
     }
 }


### PR DESCRIPTION
This PR adds 100% test coverage (according to codecov) :tada: 

- 4f74611:  Simplified how `FrameData` is being extracted from the `StackFrame`. I had previously assumed that `StackFrame.GetMethod()` could return `null`, because `Type.GetMethod()` *can*. [Microsoft assures me that it wont](https://referencesource.microsoft.com/#mscorlib/system/diagnostics/stackframe.cs,177).
- cdff287: fixed an embarrasing typo which meant that `DeviceData.BatteryLevel` would return `null` even if set, as it attempted to cast `["arch"]` to a `bool?`, rather than `["battery_level"]` 
- b9c17c5: removed the `AbsolutePath` property from `StackFrame`, it's never set, and rarely available (often not very helpful either), as it can often be found or extrapolated by classname / namespace, which always is provided.

There are also some minor tweaks