### PR TITLE
Release 1.0.3

### DIFF
--- a/src/Pidget.AspNet/Pidget.AspNet.csproj
+++ b/src/Pidget.AspNet/Pidget.AspNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 

--- a/src/Pidget.AspNet/RequestDataProvider.cs
+++ b/src/Pidget.AspNet/RequestDataProvider.cs
@@ -14,8 +14,8 @@ namespace Pidget.AspNet
         public RequestDataProvider(RequestSanitizer sanitizer)
             => _sanitizer = sanitizer;
 
-        public RequestData GetRequestData(HttpRequest request)
-            => new RequestData
+        public HttpData GetRequestData(HttpRequest request)
+            => new HttpData
             {
                 Method = request.Method,
                 Url = GetUrl(request),
@@ -48,7 +48,7 @@ namespace Pidget.AspNet
                 ? _sanitizer.SanitizeHeaders(request)
                 : null;
 
-        public object GetData(HttpRequest request)
+        public IDictionary<string, string> GetData(HttpRequest request)
             => IsUrlEncodedForm(request.ContentType)
                 ? GetForm(request)
                 : null;

--- a/src/Pidget.AspNet/SentryMiddleware.cs
+++ b/src/Pidget.AspNet/SentryMiddleware.cs
@@ -2,10 +2,10 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Pidget.AspNet.Sanitizing;
 using Pidget.Client;
+using Pidget.Client.DataModels;
 using System;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
-using Pidget.Client.DataModels;
 
 namespace Pidget.AspNet
 {

--- a/src/Pidget.AspNet/SentryMiddleware.cs
+++ b/src/Pidget.AspNet/SentryMiddleware.cs
@@ -20,14 +20,14 @@ namespace Pidget.AspNet
         private readonly RateLimit _rateLimit;
 
         public SentryMiddleware(RequestDelegate next,
-            IConfigureOptions<SentryOptions> optionSetup,
+            IConfigureOptions<SentryOptions> optionsSetup,
             SentryClient sentryClient,
             RateLimit rateLimit)
         {
             _next = next;
             _sentryClient = sentryClient;
             _rateLimit = rateLimit;
-            Options = GetOptions(optionSetup);
+            Options = GetOptions(optionsSetup);
         }
 
         private SentryOptions GetOptions(IConfigureOptions<SentryOptions> optionSetup)

--- a/src/Pidget.AspNet/SentryMiddleware.cs
+++ b/src/Pidget.AspNet/SentryMiddleware.cs
@@ -98,12 +98,12 @@ namespace Pidget.AspNet
         private UserData GetUserData(HttpContext http)
             => UserDataProvider.GetUserData(http);
 
-        private RequestData GetRequestData(HttpRequest req)
+        private HttpData GetRequestData(HttpRequest request)
         {
             var provider = new RequestDataProvider(
                 new RequestSanitizer(Options.Sanitation));
 
-            return provider.GetRequestData(req);
+            return provider.GetRequestData(request);
         }
 
         /// <summary>

--- a/src/Pidget.Client/DataModels/DeviceData.cs
+++ b/src/Pidget.Client/DataModels/DeviceData.cs
@@ -1,8 +1,8 @@
 namespace Pidget.Client.DataModels
 {
     /// <summary>
-    /// Describes the device that caused an event,
-    /// most appropriate for mobile applications.
+    /// Describes the device that caused an event.
+    /// Most appropriate for mobile applications.
     /// </summary>
     public class DeviceData : ArbitraryData
     {

--- a/src/Pidget.Client/DataModels/HttpData.cs
+++ b/src/Pidget.Client/DataModels/HttpData.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Pidget.Client.DataModels
 {
-    public class RequestData
+    public class HttpData
     {
         [JsonProperty("url")]
         public string Url { get; set; }

--- a/src/Pidget.Client/DataModels/OperatingSystemData.cs
+++ b/src/Pidget.Client/DataModels/OperatingSystemData.cs
@@ -1,7 +1,7 @@
 namespace Pidget.Client.DataModels
 {
     /// <summary>
-    /// Defines the operating system that caused an event.
+    /// Defines the operating system which caused an event.
     /// </summary>
     public class OperatingSystemData : ArbitraryData
     {

--- a/src/Pidget.Client/DataModels/RequestData.cs
+++ b/src/Pidget.Client/DataModels/RequestData.cs
@@ -12,7 +12,7 @@ namespace Pidget.Client.DataModels
         public string Method { get; set; }
 
         [JsonProperty("data")]
-        public object Data { get; set; }
+        public IDictionary<string, string> Data { get; set; }
 
         [JsonProperty("query_string")]
         public string QueryString { get; set; }
@@ -23,7 +23,7 @@ namespace Pidget.Client.DataModels
         [JsonProperty("cookies")]
         public string Cookies { get; set; }
 
-        [JsonProperty("environment")]
+        [JsonProperty("env")]
         public IDictionary<string, string> Environment { get; set; }
     }
 }

--- a/src/Pidget.Client/DataModels/SentryEventData.cs
+++ b/src/Pidget.Client/DataModels/SentryEventData.cs
@@ -37,7 +37,7 @@ namespace Pidget.Client.DataModels
         public IDictionary<string, string> Tags { get; set; }
 
         [JsonProperty("request")]
-        public RequestData Request { get; set; }
+        public HttpData Request { get; set; }
 
         [JsonProperty("user")]
         public UserData User { get; set; }

--- a/src/Pidget.Client/DataModels/StackTraceData.cs
+++ b/src/Pidget.Client/DataModels/StackTraceData.cs
@@ -6,6 +6,10 @@ using System.Linq;
 
 namespace Pidget.Client.DataModels
 {
+    /// <summary>
+    /// Contains a list with frames, each with various bits of information describing the context of that frame.
+    /// Frames should be sorted from oldest to newest.
+    /// </summary>
     public class StackTraceData
     {
         [JsonProperty("frames")]

--- a/src/Pidget.Client/DataModels/UserData.cs
+++ b/src/Pidget.Client/DataModels/UserData.cs
@@ -1,5 +1,8 @@
 namespace Pidget.Client.DataModels
 {
+    /// <summary>
+    /// Describes the authenticated User for a request.
+    /// </summary>
     public class UserData : ArbitraryData
     {
         public string Id

--- a/src/Pidget.Client/Dsn.cs
+++ b/src/Pidget.Client/Dsn.cs
@@ -2,12 +2,29 @@ using System;
 
 namespace Pidget.Client
 {
+    /// <summary>
+    /// Represents a sentry DSN, or "Data Source Name".
+    /// You can set up a project at https://sentry.io to get a new DSN.
+    /// </summary>
     public class Dsn
     {
+        /// <summary>
+        /// The underlaying URI which stores the DSN.
+        /// </summary>
         public Uri Uri { get; }
 
         private Dsn(Uri uri)
             => Uri = uri;
+
+        /// <summary>
+        /// Creates a new DSN from the provided DSN string.
+        /// </summary>
+        public static Dsn Create(string dsn)
+        {
+            Assert.ArgumentNotNull(dsn, nameof(dsn));
+
+            return new Dsn(new Uri(dsn));
+        }
 
         public string GetProjectId()
             => Uri.AbsoluteUri.Substring(
@@ -23,12 +40,12 @@ namespace Pidget.Client
         public string GetSecretKey()
             => Uri.UserInfo.Split(':')[1];
 
-        private int LastIndexOfSlash(string input)
-            => input.LastIndexOf('/');
-
         public override string ToString()
             => Uri.ToString();
 
+        /// <summary>
+        /// Gets the URL for where to POST events to.
+        /// </summary>
         public string GetCaptureUrl()
             => string.Concat(
                 Uri.Scheme,
@@ -39,11 +56,7 @@ namespace Pidget.Client
                 GetProjectId(),
                 "/store/");
 
-        public static Dsn Create(string dsn)
-        {
-            Assert.ArgumentNotNull(dsn, nameof(dsn));
-
-            return new Dsn(new Uri(dsn));
-        }
+        private int LastIndexOfSlash(string input)
+            => input.LastIndexOf('/');
     }
 }

--- a/src/Pidget.Client/Pidget.Client.csproj
+++ b/src/Pidget.Client/Pidget.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 

--- a/src/Pidget.Client/Sentry.cs
+++ b/src/Pidget.Client/Sentry.cs
@@ -5,13 +5,23 @@ namespace Pidget.Client
 {
     public static class Sentry
     {
+        /// <summary>
+        /// The Sentry protocol version which the client uses.
+        /// </summary>
         public const string CurrentProtocolVersion = "7";
 
         internal const string CSharpPlatformIdentifier = "csharp";
 
+        /// <summary>
+        /// The encoding which the Sentry API uses.
+        /// </summary>
         public static Encoding ApiEncoding { get; }
             = new UTF8Encoding(false, false);
 
+        /// <summary>
+        /// Creates a new client using the provided DSN.
+        /// </summary>
+        /// <param name="dsn">The Sentry DSN, or Data Source Name.</param>
         public static SentryClient CreateClient(Dsn dsn)
             => SentryHttpClient.Default(dsn);
     }

--- a/src/Pidget.Client/SentryClient.cs
+++ b/src/Pidget.Client/SentryClient.cs
@@ -6,27 +6,51 @@ namespace Pidget.Client
 {
     public abstract class SentryClient
     {
+        /// <summary>
+        /// The name of the client, used in e.g. the User-Agent.
+        /// </summary>
         public const string Name = "pidget";
 
+        /// <summary>
+        /// The current version of Pidget.
+        /// </summary>
         public static string Version { get; }
             = VersionNumber.Get();
 
+        /// <summary>
+        /// The DSN which determines which project this client is configured for.
+        /// </summary>
         public Dsn Dsn { get; }
 
+        /// <summary>
+        /// Determines whether the client can send events.
+        /// The client gets disabled if a DSN of null is provided.
+        /// </summary>
         public bool IsEnabled => Dsn != null;
 
+        /// <summary>
+        /// Sets the provided DSN for the client.
+        /// </summary>
         protected SentryClient(Dsn dsn)
             => Dsn = dsn;
 
+        /// <summary>
+        /// Builds and captures a sentry event, using <see cref="SendEventAsync" />
+        /// </summary>
+        /// <param name="builderConfig">Configures the event to send.</param>
         public Task<SentryResponse> CaptureAsync(
-            Action<SentryEventBuilder> builderAccessor)
+            Action<SentryEventBuilder> builderConfig)
         {
             var builder = new SentryEventBuilder();
-            builderAccessor(builder);
+            builderConfig(builder);
 
             return SendEventAsync(builder.Build());
         }
 
+        /// <summary>
+        /// Sends the provided event data to Sentry and returns its response.
+        /// </summary>
+        /// <param name="sentryEvent">The sentry event data</param>
         public abstract Task<SentryResponse> SendEventAsync(
             SentryEventData sentryEvent);
     }

--- a/src/Pidget.Client/SentryEventBuilder.cs
+++ b/src/Pidget.Client/SentryEventBuilder.cs
@@ -33,7 +33,7 @@ namespace Pidget.Client
 
 
         /// <summary>
-        /// Sets the captured exception.
+        /// Sets an exception.
         /// </summary>
         /// <param name="exception">The exception to capture.</param>
         public SentryEventBuilder SetException(Exception exception)
@@ -120,7 +120,7 @@ namespace Pidget.Client
             return this;
         }
 
-         /// <summary>
+        /// <summary>
         /// Adds a collection of extra data to the event.
         /// </summary>
         /// <param name="data">A collection of named data.</param>
@@ -146,6 +146,11 @@ namespace Pidget.Client
             return this;
         }
 
+        /// <summary>
+        /// Sets data regarding the current authenticated user.
+        /// You should provide at least either a unique user ID, or an IP-address.
+        /// </summary>
+        /// <param name="user">Information regarding the current user.</param>
         public SentryEventBuilder SetUserData(UserData user)
         {
             _userData = user;
@@ -153,6 +158,11 @@ namespace Pidget.Client
             return this;
         }
 
+        /// <summary>
+        /// Sets data regarding the current HTTP request.
+        /// A URL and method must be set.
+        /// </summary>
+        /// <param name="request">Information regarding the current request.</param>
         public SentryEventBuilder SetRequestData(HttpData request)
         {
             _requestData = request;
@@ -160,6 +170,9 @@ namespace Pidget.Client
             return this;
         }
 
+        /// <summary>
+        /// Sets additional contextual data
+        /// </summary>
         public SentryEventBuilder SetContexts(ContextsData contexts)
         {
             _contextsData = contexts;
@@ -167,6 +180,9 @@ namespace Pidget.Client
             return this;
         }
 
+        /// <summary>
+        /// Builds the event, creating event data.
+        /// </summary>
         public SentryEventData Build()
         {
             AssertValidity();

--- a/src/Pidget.Client/SentryEventBuilder.cs
+++ b/src/Pidget.Client/SentryEventBuilder.cs
@@ -17,7 +17,7 @@ namespace Pidget.Client
 
         private ErrorLevel _errorLevel;
 
-        private RequestData _requestData;
+        private HttpData _requestData;
 
         private UserData _userData;
 
@@ -153,7 +153,7 @@ namespace Pidget.Client
             return this;
         }
 
-        public SentryEventBuilder SetRequestData(RequestData request)
+        public SentryEventBuilder SetRequestData(HttpData request)
         {
             _requestData = request;
 

--- a/src/Pidget.Client/SentryEventBuilder.cs
+++ b/src/Pidget.Client/SentryEventBuilder.cs
@@ -21,6 +21,8 @@ namespace Pidget.Client
 
         private UserData _userData;
 
+        private ContextsData _contextsData;
+
         private readonly Dictionary<string, string> _tags
             = new Dictionary<string, string>(4);
 
@@ -28,9 +30,6 @@ namespace Pidget.Client
             = new Dictionary<string, object>(4);
 
         private readonly List<string> _fingerprint = new List<string>(4);
-
-        private ContextsData _contextsData;
-
 
         /// <summary>
         /// Sets an exception.

--- a/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
+++ b/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
@@ -36,7 +36,7 @@ namespace Pidget.Client.Test
         {
             var httpClient = SentryHttpClient.CreateDefaultHttpClient();
 
-            Assert.Equal(SentryHttpClient.UserAgent,
+            Assert.Equal(SentryHttpClient.DefaultUserAgent,
                 httpClient.DefaultRequestHeaders.UserAgent.ToString());
         }
 

--- a/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
+++ b/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
@@ -30,7 +30,6 @@ namespace Pidget.Client.Test
             => Assert.Throws<ArgumentNullException>(()
                 => new SentryHttpClient(DsnTests.SentryDsn, null));
 
-
         [Fact]
         public void Sender_HasExpectedUserAgent()
         {

--- a/test/Pidget.Client.Test/SentryEventBuilderTests.cs
+++ b/test/Pidget.Client.Test/SentryEventBuilderTests.cs
@@ -123,7 +123,7 @@ namespace Pidget.Client.Test
         [Fact]
         public void SetRequestData()
         {
-            var expectedData = new RequestData();
+            var expectedData = new HttpData();
 
             var builder = new SentryEventBuilder()
                 .SetException(new Exception())


### PR DESCRIPTION
- Fixes the member JSON property name of the newly implemented HTTP environment support. `"environment"` &rarr; `"env"` [according to the docs](https://docs.sentry.io/clientdev/interfaces/http/).
- Adds documentations to a few commonly used methods.
- Rename `RequestData` &rarr; `HttpData` to more strictly conform to the "[HTTP interface](https://docs.sentry.io/clientdev/interfaces/http/)".
- Fixes some typos