### PR TITLE
New DSN support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 dist: trusty
 mono: none
-dotnet: 2.1.0
+dotnet: 2.1
 
 install:
   - dotnet restore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: csharp
 dist: trusty
 mono: none
-dotnet: 2.0.0
+dotnet: 2.1.0
 
 install:
-- dotnet restore
+  - dotnet restore
 
 script:
-# Only run codecov:
-# - he build
-# - he test
-# - he report
-# but most importantly
-# - he protec
-- sh codecov.sh
+  # Only run codecov:
+  # - he build
+  # - he test
+  # - he report
+  # but most importantly
+  # - he protec
+  - sh codecov.sh

--- a/src/Pidget.Client/DataModels/FrameData.cs
+++ b/src/Pidget.Client/DataModels/FrameData.cs
@@ -20,7 +20,7 @@ namespace Pidget.Client.DataModels
         public string Module { get; set; }
 
         [JsonProperty("function")]
-        public string Function { get; set;}
+        public string Function { get; set; }
 
         [JsonProperty(PropertyName = "context_line")]
         public string ContextLine { get; set; }

--- a/src/Pidget.Client/Dsn.cs
+++ b/src/Pidget.Client/Dsn.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace Pidget.Client
 {
@@ -35,10 +36,12 @@ namespace Pidget.Client
                 LastIndexOfSlash(Uri.AbsolutePath) + 1);
 
         public string GetPublicKey()
-            => Uri.UserInfo.Split(':')[0];
+            => Uri.UserInfo.Split(':')
+                .ElementAtOrDefault(0);
 
         public string GetSecretKey()
-            => Uri.UserInfo.Split(':')[1];
+            => Uri.UserInfo.Split(':')
+                .ElementAtOrDefault(1);
 
         public override string ToString()
             => Uri.ToString();

--- a/src/Pidget.Client/Http/SentryAuth.cs
+++ b/src/Pidget.Client/Http/SentryAuth.cs
@@ -28,8 +28,11 @@ namespace Pidget.Client.Http
         }
 
         public static SentryAuth Issue(Dsn dsn, DateTimeOffset issuedAt)
-            => new SentryAuth(sentryVersion: Sentry.CurrentProtocolVersion,
-                clientVersion: string.Join("/", $"{SentryClient.Name}-csharp", SentryClient.Version),
+            => new SentryAuth(
+                sentryVersion: Sentry.CurrentProtocolVersion,
+                clientVersion: string.Join("/",
+                    $"{SentryClient.Name}-csharp",
+                    SentryClient.Version),
                 timestamp: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                 publicKey: dsn.GetPublicKey(),
                 secretKey: dsn.GetSecretKey());

--- a/src/Pidget.Client/Http/SentryAuthHeader.cs
+++ b/src/Pidget.Client/Http/SentryAuthHeader.cs
@@ -7,14 +7,18 @@ namespace Pidget.Client.Http
         public const string Name = "X-Sentry-Auth";
 
         public static IEnumerable<string> GetValues(SentryAuth auth)
-            => new[]
+        {
+            yield return Combine("Sentry sentry_version", auth.SentryVersion);
+            yield return Combine("sentry_timestamp", auth.Timestamp);
+            yield return Combine("sentry_key", auth.PublicKey);
+
+            if (auth.SecretKey != null)
             {
-                Combine("Sentry sentry_version", auth.SentryVersion),
-                Combine("sentry_timestamp", auth.Timestamp),
-                Combine("sentry_key", auth.PublicKey),
-                Combine("sentry_secret", auth.SecretKey),
-                Combine("sentry_client", auth.ClientVersion)
-            };
+                yield return Combine("sentry_secret", auth.SecretKey);
+            }
+
+            yield return Combine("sentry_client", auth.ClientVersion);
+        }
 
         private static string Combine(string key, object value)
             => $"{key}={value}";

--- a/src/Pidget.Client/Http/SentryHttpClient.cs
+++ b/src/Pidget.Client/Http/SentryHttpClient.cs
@@ -13,7 +13,7 @@ using static System.Threading.CancellationToken;
 namespace Pidget.Client.Http
 {
     /// <summary>
-    /// The shipped default implementation of the SentryClient.
+    /// The default implementation of the SentryClient.
     /// </summary>
     public class SentryHttpClient : SentryClient
     {

--- a/test/Pidget.Client.Test/Dsns.cs
+++ b/test/Pidget.Client.Test/Dsns.cs
@@ -1,0 +1,23 @@
+namespace Pidget.Client.Test
+{
+    public static class Dsns
+    {
+        public const string PublicKey = "public_key";
+
+        public const string SecretKey = "secret_key";
+
+        public const string Host = "host";
+
+        public const string ProjectId = "project_id";
+
+        public const string Path = "/path/";
+
+
+        public const string SentryDsn =
+            "https://" + PublicKey + "@" + Host + Path + ProjectId;
+
+        public const string LegacyDsn =
+            "https://" + PublicKey + ":" + SecretKey + "@" +
+            Host + Path + ProjectId;
+    }
+}

--- a/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
+++ b/test/Pidget.Client.Test/Http/SentryHttpClientTests.cs
@@ -17,6 +17,9 @@ namespace Pidget.Client.Test
 
     public class SentryHttpClientTests
     {
+
+        public static readonly Dsn Dsn = Dsn.Create(Dsns.SentryDsn);
+
         public const string EventId = "event_id";
 
         public static SentryResponse OkResponse { get; }
@@ -28,7 +31,7 @@ namespace Pidget.Client.Test
         [Fact]
         public void RequiresHttpClient()
             => Assert.Throws<ArgumentNullException>(()
-                => new SentryHttpClient(DsnTests.SentryDsn, null));
+                => new SentryHttpClient(Dsn, null));
 
         [Fact]
         public void Sender_HasExpectedUserAgent()
@@ -43,9 +46,7 @@ namespace Pidget.Client.Test
         public async Task SendMessageEvent(string message)
         {
             var senderMock = new Mock<HttpClient>();
-
-            var client = new SentryHttpClient(DsnTests.SentryDsn,
-                senderMock.Object);
+            var client = new SentryHttpClient(Dsn, senderMock.Object);
 
             senderMock.Setup(m => m.SendAsync(It.IsAny<HttpRequestMessage>(), None))
                 .ReturnsAsync(CreateOkHttpResponse(JsonSerializer.CreateDefault()))
@@ -83,13 +84,13 @@ namespace Pidget.Client.Test
 
         [Fact]
         public void CreateDefault()
-            => Assert.NotNull(
-                SentryHttpClient.Default(DsnTests.SentryDsn));
+            => Assert.NotNull(SentryHttpClient.Default(Dsn));
 
         [Fact(Skip = "Manual testing only")]
         public async Task SendException_ReturnsEventId()
         {
-            var client = Sentry.CreateClient(Dsn.Create(GetProductionDsn()));
+            var dsn = "<YOUR DSN HERE>";
+            var client = Sentry.CreateClient(Dsn.Create(dsn));
 
             var value = 0;
 
@@ -128,19 +129,6 @@ namespace Pidget.Client.Test
                 StatusCode = HttpStatusCode.OK,
                 Content = content
             };
-        }
-
-        private static string GetProductionDsn()
-        {
-            var filePath = Path.Combine(Directory.GetCurrentDirectory(),
-                "dsn.txt");
-
-            if (!File.Exists(filePath))
-            {
-                return null;
-            }
-
-            return File.ReadAllText(filePath).Trim();
         }
     }
 }

--- a/test/Pidget.Client.Test/SentryTests.cs
+++ b/test/Pidget.Client.Test/SentryTests.cs
@@ -9,6 +9,6 @@ namespace Pidget.Client.Test
     {
         [Fact]
         public void CreateClient_IsSentryHttpClient()
-            => Assert.True(Sentry.CreateClient(DsnTests.SentryDsn) is SentryHttpClient);
+            => Assert.True(Sentry.CreateClient(Dsn.Create(Dsns.SentryDsn)) is SentryHttpClient);
     }
 }

--- a/test/Pidget.Client.Test/dsn.example.txt
+++ b/test/Pidget.Client.Test/dsn.example.txt
@@ -1,1 +1,0 @@
-# Paste your Sentry DSN in a file called "dsn.txt" at this file location


### PR DESCRIPTION
Sentry updated their DSN format some time ago, it now only uses the `public_key` part. The `secret_key`, is now optional and deprecated.

From the new "Client key (DSN) page":

> **DSN (Deprecated)**
> This DSN includes the secret which is no longer required by Sentry or newer versions of SDKs.

This project has not stayed up-to-date, and the private key has previously been required; although, it should have been optional from the get-go.

Either way: 
Solves #49 